### PR TITLE
League mobile ux update

### DIFF
--- a/src/components/league/latest-matches-section.tsx
+++ b/src/components/league/latest-matches-section.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
 import { Button } from "~/components/ui/button";
 import { PlusIcon } from "@radix-ui/react-icons";
@@ -15,7 +15,7 @@ import {
   TableRow,
 } from "~/components/ui/table";
 
-export const LatestMatchesCard = ({
+export const LatestMatchesSection = ({
   leagueSlug,
   className,
 }: {
@@ -38,7 +38,7 @@ export const LatestMatchesCard = ({
   const hasLessThanTwoPlayers = seasonPlayers && seasonPlayers.length < 2;
 
   return (
-    <Card className={className}>
+    <div className={className}>
       <CardHeader>
         <div className={"flex items-center"}>
           <CardTitle className={"grow"}>
@@ -102,6 +102,6 @@ export const LatestMatchesCard = ({
           </Table>
         </div>
       </CardContent>
-    </Card>
+    </div>
   );
 };

--- a/src/components/league/ongoing-season-section.tsx
+++ b/src/components/league/ongoing-season-section.tsx
@@ -3,11 +3,11 @@
 import { SeasonStanding } from "~/components/league/standing";
 import { Spinner } from "~/components/spinner";
 import { Button } from "~/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import { CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { useRouter } from "next/router";
 import { api } from "~/lib/api";
 
-export const OngoingSeasonCard = ({
+export const OngoingSeasonSection = ({
   className,
   leagueSlug,
 }: {
@@ -44,7 +44,7 @@ export const OngoingSeasonCard = ({
   };
 
   return (
-    <Card className={className}>
+    <div className={className}>
       <CardHeader>
         <div className="flex">
           <div className="grow">
@@ -63,6 +63,6 @@ export const OngoingSeasonCard = ({
       <CardContent>
         <div className="grid">{cardContent()}</div>
       </CardContent>
-    </Card>
+    </div>
   );
 };

--- a/src/pages/leagues/[leagueSlug]/index.tsx
+++ b/src/pages/leagues/[leagueSlug]/index.tsx
@@ -2,10 +2,10 @@ import { type GetServerSidePropsContext, type NextPage } from "next";
 import { InFormCard } from "~/components/league/in-form-card";
 import { LeagueDetailsLayout } from "~/components/league/league-details-layout";
 import { MatchesPlayedCard } from "~/components/league/match-count-card";
-import { OngoingSeasonCard } from "~/components/league/ongoing-season-card";
+import { OngoingSeasonSection } from "~/components/league/ongoing-season-section";
 import { LatestMatchCard } from "~/components/match/latest-match-card";
 import { useLeagueSlug } from "~/hooks/useLeagueSlug";
-import { LatestMatchesCard } from "~/components/league/latest-matches-card";
+import { LatestMatchesSection } from "~/components/league/latest-matches-section";
 import { setCookie } from "cookies-next";
 
 export const latestOpenLeagueCookie = "latestOpenLeagueCookie";
@@ -26,8 +26,8 @@ const LeagueDetails: NextPage = () => {
         <LatestMatchCard leagueSlug={leagueSlug} />
       </div>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-8">
-        <OngoingSeasonCard leagueSlug={leagueSlug} className="col-span-4" />
-        <LatestMatchesCard leagueSlug={leagueSlug} className="col-span-4" />
+        <OngoingSeasonSection leagueSlug={leagueSlug} className="col-span-4" />
+        <LatestMatchesSection leagueSlug={leagueSlug} className="col-span-4" />
       </div>
     </LeagueDetailsLayout>
   );


### PR DESCRIPTION
- Remove card wrapper around ongoing season and latest matches so it fits better in mobile and also to show more clearly difference between statistics cards and the data tables


https://github.com/palmithor/scorebrawl/assets/37415686/eeb70e59-7e39-4d4c-8150-3a8aab4d6d7f

