### PR TITLE
fix: prevent 401 on organization list after signup

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import Landing from "@/components/landing";
 import { authClient } from "@/lib/auth-client";
@@ -13,9 +14,16 @@ export const Route = createFileRoute("/")({
 
 function App() {
 	const { session } = Route.useRouteContext();
-	const { data: organizations, isPending } = authClient.useListOrganizations();
-
 	const navigate = useNavigate();
+
+	const { data: organizations, isPending } = useQuery({
+		queryKey: ["organizations"],
+		queryFn: async () => {
+			const { data } = await authClient.organization.list();
+			return data;
+		},
+		enabled: !!session,
+	});
 
 	if (!session) {
 		return <Landing />;


### PR DESCRIPTION
Fixes blank page issue after signup where `/api/auth/organization/list` returned 401.

**Problem:**
After email signup, users saw a blank page and had to refresh. The console showed a 401 error on the organization list endpoint.

**Root Cause:**
`authClient.useListOrganizations()` fires immediately on mount, before the session cookie is fully established after signup.

**Solution:**
Replace the better-auth hook with TanStack Query's `useQuery` with `enabled: !!session` option. This ensures the API call only happens when the session is confirmed.

**Changes:**
- `apps/web/src/routes/index.tsx`: Use `useQuery` with `enabled` option instead of `authClient.useListOrganizations()`