### PR TITLE
feat: add scorebrawl.com custom domain

### DIFF
--- a/.github/scripts/preview/prepare-wrangler-config.ts
+++ b/.github/scripts/preview/prepare-wrangler-config.ts
@@ -31,6 +31,9 @@ config.d1_databases[0].database_name = dbName;
 config.d1_databases[0].migrations_dir = "./apps/worker/migrations";
 config.r2_buckets[0].bucket_name = bucketName;
 
+// Remove custom domain routes for preview
+config.routes = undefined;
+
 // Write preview config
 const previewConfigPath = "wrangler.preview.jsonc";
 await Bun.write(previewConfigPath, JSON.stringify(config, null, "\t"));

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -28,6 +28,12 @@
 		"R2_ACCOUNT_ID": "",
 		"USER_ASSETS_BUCKET_NAME": "scorebrawl-user-assets"
 	},
+	"routes": [
+		{
+			"pattern": "scorebrawl.com",
+			"custom_domain": true
+		}
+	],
 	"upload_source_maps": true,
 	"assets": {
 		"directory": "../../apps/web/dist/client",


### PR DESCRIPTION
## Summary
- Add `scorebrawl.com` as a custom production domain in `apps/worker/wrangler.jsonc`
- Strip custom domain routes from preview wrangler config to prevent preview deployments from claiming the production domain