### PR TITLE
feat: implement local-first architecture with TanStack DB

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,13 +13,17 @@
 	},
 	"dependencies": {
 		"@base-ui/react": "catalog:",
+		"@coding-cowboys/scorebrawl-worker": "workspace:*",
 		"@fontsource-variable/jetbrains-mono": "catalog:",
 		"@hugeicons/core-free-icons": "catalog:",
 		"@hugeicons/react": "catalog:",
 		"@tanstack/devtools-vite": "catalog:",
+		"@tanstack/query-db-collection": "^1.0.22",
+		"@tanstack/react-db": "^0.1.69",
 		"@tanstack/react-query": "catalog:",
 		"@tanstack/react-router": "catalog:",
 		"@tanstack/react-router-devtools": "catalog:",
+		"@tanstack/react-virtual": "^3.13.18",
 		"@tanstack/router-plugin": "catalog:",
 		"@tanstack/zod-adapter": "catalog:",
 		"@trpc/client": "catalog:",
@@ -46,8 +50,7 @@
 		"tailwindcss": "catalog:",
 		"tw-animate-css": "catalog:",
 		"vaul": "catalog:",
-		"web-vitals": "catalog:",
-		"@coding-cowboys/scorebrawl-worker": "workspace:*"
+		"web-vitals": "catalog:"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "catalog:",

--- a/apps/web/src/components/match/match-row.tsx
+++ b/apps/web/src/components/match/match-row.tsx
@@ -1,0 +1,108 @@
+import { useQuery } from "@tanstack/react-query";
+import { trpcClient } from "@/lib/trpc";
+import { AvatarWithFallback } from "@/components/ui/avatar-with-fallback";
+
+interface MatchPlayer {
+	id: string;
+	seasonPlayerId: string;
+	homeTeam: boolean;
+	result: "W" | "L" | "D";
+	scoreBefore: number;
+	scoreAfter: number;
+	name: string;
+	image: string | null;
+	teamName: string | null;
+}
+
+interface MatchRowProps {
+	match: {
+		id: string;
+		homeScore: number;
+		awayScore: number;
+		createdAt: Date;
+	};
+	seasonSlug: string;
+}
+
+function getSideLabel(players: MatchPlayer[]): string {
+	if (players.length === 0) return "Unknown";
+	const teamNames = players.map((p) => p.teamName).filter(Boolean);
+	const uniqueTeams = [...new Set(teamNames)];
+	if (uniqueTeams.length === 1 && teamNames.length === players.length) {
+		return uniqueTeams[0] ?? "Unknown";
+	}
+	return players.map((p) => p.name).join(", ");
+}
+
+function formatDate(date: Date) {
+	const now = new Date();
+	const matchDate = new Date(date);
+
+	const isToday =
+		now.getFullYear() === matchDate.getFullYear() &&
+		now.getMonth() === matchDate.getMonth() &&
+		now.getDate() === matchDate.getDate();
+
+	if (isToday) {
+		const diffMs = now.getTime() - matchDate.getTime();
+		const diffMinutes = Math.floor(diffMs / (1000 * 60));
+
+		if (diffMinutes < 60) {
+			return diffMinutes <= 1 ? "1m ago" : `${diffMinutes}m ago`;
+		}
+		const diffHours = Math.floor(diffMinutes / 60);
+		return `${diffHours}h ago`;
+	}
+	return matchDate.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export function MatchRow({ match, seasonSlug }: MatchRowProps) {
+	const { data: matchDetails } = useQuery<{ players: MatchPlayer[] } | null>({
+		queryKey: ["match", "details", match.id],
+		queryFn: async () => {
+			return await trpcClient.match.getById.query({ seasonSlug, matchId: match.id });
+		},
+		enabled: !!match.id,
+	});
+
+	const homePlayers = matchDetails?.players?.filter((p) => p.homeTeam) ?? [];
+	const awayPlayers = matchDetails?.players?.filter((p) => !p.homeTeam) ?? [];
+
+	return (
+		<div className="flex items-center justify-between gap-4 p-4">
+			<div className="flex flex-col gap-2 min-w-0 flex-1">
+				<div className="flex items-center gap-2 min-w-0">
+					<div className="flex gap-1 shrink-0">
+						{homePlayers.map((player) => (
+							<AvatarWithFallback key={player.id} src={player.image} name={player.name} size="sm" />
+						))}
+					</div>
+					<span className="text-xs text-muted-foreground truncate">
+						{getSideLabel(homePlayers)}
+					</span>
+				</div>
+				<div className="flex items-center gap-2 min-w-0">
+					<div className="flex gap-1 shrink-0">
+						{awayPlayers.map((player) => (
+							<AvatarWithFallback key={player.id} src={player.image} name={player.name} size="sm" />
+						))}
+					</div>
+					<span className="text-xs text-muted-foreground truncate">
+						{getSideLabel(awayPlayers)}
+					</span>
+				</div>
+			</div>
+			<div className="flex items-center gap-4 flex-shrink-0">
+				<div className="text-center font-bold text-sm">
+					{match.homeScore} - {match.awayScore}
+				</div>
+				<div className="text-xs text-muted-foreground text-right min-w-[60px]">
+					{formatDate(match.createdAt)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/season/overview-card.tsx
+++ b/apps/web/src/components/season/overview-card.tsx
@@ -5,14 +5,20 @@ interface OverviewCardProps {
 	title: string;
 	description?: string;
 	children: ReactNode;
+	action?: ReactNode;
 }
 
-export function OverviewCard({ title, description, children }: OverviewCardProps) {
+export function OverviewCard({ title, description, children, action }: OverviewCardProps) {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>{title}</CardTitle>
-				{description && <CardDescription>{description}</CardDescription>}
+				<div className="flex items-center justify-between">
+					<div>
+						<CardTitle>{title}</CardTitle>
+						{description && <CardDescription>{description}</CardDescription>}
+					</div>
+					{action && <div>{action}</div>}
+				</div>
 			</CardHeader>
 			<CardContent>{children}</CardContent>
 		</Card>

--- a/apps/web/src/components/season/standing-tabs.tsx
+++ b/apps/web/src/components/season/standing-tabs.tsx
@@ -13,23 +13,22 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface StandingTabsProps {
-	slug: string;
+	seasonId: string;
 	seasonSlug: string;
 }
 
 interface TeamStandingItem {
 	id: string;
 	seasonId: string;
-	orgTeamId: string;
+	leagueTeamId: string;
 	score: number;
 	name: string;
 }
 
-function TeamStanding({ slug, seasonSlug }: { slug: string; seasonSlug: string }) {
+function TeamStanding({ seasonSlug }: { seasonSlug: string }) {
 	const { data, isLoading } = useQuery<TeamStandingItem[]>({
-		queryKey: ["seasonTeam", "standing", slug, seasonSlug],
+		queryKey: ["seasonTeam", "standing", seasonSlug],
 		queryFn: async () => {
-			// For now, return empty - will need to implement team standing endpoint
 			return [];
 		},
 	});
@@ -70,23 +69,16 @@ function TeamStanding({ slug, seasonSlug }: { slug: string; seasonSlug: string }
 	);
 }
 
-export function StandingTabs({ slug, seasonSlug }: StandingTabsProps) {
+export function StandingTabs({ seasonId, seasonSlug }: StandingTabsProps) {
 	const { data: season } = useQuery({
-		queryKey: ["season", slug, seasonSlug],
+		queryKey: ["season", seasonSlug],
 		queryFn: async () => {
 			return await trpcClient.season.getBySlug.query({ seasonSlug });
 		},
 	});
 
-	// Check if season has teams by looking at score type and team data
-	// For now, only ELO and elo-individual-vs-team seasons can have teams
-	// 3-1-0 is always individual only
 	const canHaveTeams = season?.scoreType !== "3-1-0";
-
-	// For now, we'll assume no teams exist until we implement team checking
-	// When teams are implemented, we'd check: const hasTeams = teamData && teamData.length > 0;
 	const hasTeams = false;
-
 	const showTeamStandings = canHaveTeams && hasTeams;
 
 	return (
@@ -95,15 +87,15 @@ export function StandingTabs({ slug, seasonSlug }: StandingTabsProps) {
 				<div className="space-y-6">
 					<div>
 						<h3 className="text-sm font-medium text-muted-foreground mb-3">Individual</h3>
-						<Standing slug={slug} seasonSlug={seasonSlug} />
+						<Standing seasonId={seasonId} seasonSlug={seasonSlug} />
 					</div>
 					<div>
 						<h3 className="text-sm font-medium text-muted-foreground mb-3">Team</h3>
-						<TeamStanding slug={slug} seasonSlug={seasonSlug} />
+						<TeamStanding seasonSlug={seasonSlug} />
 					</div>
 				</div>
 			) : (
-				<Standing slug={slug} seasonSlug={seasonSlug} />
+				<Standing seasonId={seasonId} seasonSlug={seasonSlug} />
 			)}
 		</OverviewCard>
 	);

--- a/apps/web/src/components/season/standing.tsx
+++ b/apps/web/src/components/season/standing.tsx
@@ -1,5 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
-import { trpcClient } from "@/lib/trpc";
+import { useStandings } from "@/lib/collections";
 import {
 	Table,
 	TableBody,
@@ -8,34 +7,16 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
-import { Skeleton } from "@/components/ui/skeleton";
 import { AvatarWithFallback } from "@/components/ui/avatar-with-fallback";
 import { cn } from "@/lib/utils";
 
 interface StandingProps {
-	slug: string;
+	seasonId: string;
 	seasonSlug: string;
 }
 
-interface StandingItem {
-	id: string;
-	seasonId: string;
-	playerId: string;
-	score: number;
-	name: string;
-	image: string | null;
-	userId: string;
-	matchCount: number;
-	winCount: number;
-	lossCount: number;
-	drawCount: number;
-	rank: number;
-	pointDiff: number;
-	form: ("W" | "D" | "L")[];
-}
-
-function FormDots({ form }: { form: ("W" | "D" | "L")[] }) {
-	if (form.length === 0) {
+function FormDots({ form }: { form: ("W" | "D" | "L")[] | undefined }) {
+	if (!form || form.length === 0) {
 		return (
 			<div className="flex gap-1 justify-center">
 				<span className="text-muted-foreground text-xs">-</span>
@@ -64,19 +45,10 @@ function FormDots({ form }: { form: ("W" | "D" | "L")[] }) {
 	);
 }
 
-export function Standing({ slug, seasonSlug }: StandingProps) {
-	const { data, isLoading } = useQuery<StandingItem[]>({
-		queryKey: ["seasonPlayer", "standing", slug, seasonSlug],
-		queryFn: async () => {
-			return await trpcClient.seasonPlayer.getStanding.query({ seasonSlug });
-		},
-	});
+export function Standing({ seasonId, seasonSlug }: StandingProps) {
+	const { standings } = useStandings(seasonId, seasonSlug);
 
-	if (isLoading) {
-		return <Skeleton className="w-full h-80" />;
-	}
-
-	if (!data?.length) {
+	if (standings.length === 0) {
 		return (
 			<div className="flex items-center justify-center h-40 text-muted-foreground">
 				No matches registered
@@ -84,8 +56,7 @@ export function Standing({ slug, seasonSlug }: StandingProps) {
 		);
 	}
 
-	// Sort: players with 0 matches go to bottom, then by score descending
-	const sortedData = [...data].sort((a, b) => {
+	const sortedData = [...standings].sort((a, b) => {
 		if (a.matchCount === 0 && b.matchCount !== 0) return 1;
 		if (a.matchCount !== 0 && b.matchCount === 0) return -1;
 		return b.score - a.score;

--- a/apps/web/src/lib/collections/index.ts
+++ b/apps/web/src/lib/collections/index.ts
@@ -1,0 +1,15 @@
+export { createSeasonCollection, useSeasons, seasonSchema, type Season } from "./season-collection";
+export {
+	createMatchCollection,
+	useMatches,
+	loadMoreMatches,
+	matchSchema,
+	type Match,
+	type MatchPlayer,
+} from "./match-collection";
+export {
+	createStandingCollection,
+	useStandings,
+	standingPlayerSchema,
+	type StandingPlayer,
+} from "./standing-collection";

--- a/apps/web/src/lib/collections/match-collection.ts
+++ b/apps/web/src/lib/collections/match-collection.ts
@@ -1,0 +1,152 @@
+import { createCollection, useLiveQuery } from "@tanstack/react-db";
+import { queryCollectionOptions } from "@tanstack/query-db-collection";
+import { z } from "zod";
+import { trpcClient } from "../trpc";
+import { queryClient } from "../query-client";
+
+export const matchPlayerSchema = z.object({
+	id: z.string(),
+	seasonPlayerId: z.string(),
+	homeTeam: z.boolean(),
+	result: z.enum(["W", "D", "L"]),
+	scoreBefore: z.number(),
+	scoreAfter: z.number(),
+	name: z.string(),
+	image: z.string().nullable(),
+	teamName: z.string().nullable(),
+});
+
+export const matchSchema = z.object({
+	id: z.string(),
+	seasonId: z.string(),
+	homeScore: z.number(),
+	awayScore: z.number(),
+	createdAt: z.date(),
+	players: z.array(matchPlayerSchema),
+});
+
+export type Match = z.infer<typeof matchSchema>;
+export type MatchPlayer = z.infer<typeof matchPlayerSchema>;
+
+const matchCollections = new Map<string, ReturnType<typeof createMatchCollectionInternal>>();
+
+const PAGE_SIZE = 30;
+
+function createMatchCollectionInternal(seasonId: string, seasonSlug: string) {
+	return createCollection(
+		queryCollectionOptions({
+			id: `matches-${seasonId}`,
+			queryKey: ["matches", seasonId],
+			queryClient,
+			schema: matchSchema,
+			getKey: (item) => item.id,
+			refetchInterval: 5000, // Poll every 5 seconds for real-time updates
+			queryFn: async () => {
+				const result = await trpcClient.match.getAll.query({
+					seasonSlug,
+					limit: PAGE_SIZE,
+					offset: 0,
+				});
+				return result.matches.map((match) => ({
+					id: match.id,
+					seasonId: match.seasonId,
+					homeScore: match.homeScore,
+					awayScore: match.awayScore,
+					createdAt: match.createdAt,
+					players: [],
+				}));
+			},
+			onInsert: async ({ transaction }) => {
+				const newMatch = transaction.mutations[0]?.modified;
+				if (!newMatch) return { refetch: true };
+
+				const homePlayerIds = newMatch.players
+					.filter((p) => p.homeTeam)
+					.map((p) => p.seasonPlayerId);
+				const awayPlayerIds = newMatch.players
+					.filter((p) => !p.homeTeam)
+					.map((p) => p.seasonPlayerId);
+
+				await trpcClient.match.create.mutate({
+					id: newMatch.id,
+					seasonSlug,
+					homeScore: newMatch.homeScore,
+					awayScore: newMatch.awayScore,
+					homeTeamPlayerIds: homePlayerIds,
+					awayTeamPlayerIds: awayPlayerIds,
+				});
+
+				return { refetch: true };
+			},
+			onDelete: async ({ transaction }) => {
+				const matchId = transaction.mutations[0]?.key;
+				if (!matchId) return { refetch: true };
+
+				await trpcClient.match.remove.mutate({
+					seasonSlug,
+					matchId: matchId as string,
+				});
+
+				return { refetch: true };
+			},
+		})
+	);
+}
+
+export function createMatchCollection(seasonId: string, seasonSlug: string) {
+	const existing = matchCollections.get(seasonId);
+	if (existing) return existing;
+
+	const collection = createMatchCollectionInternal(seasonId, seasonSlug);
+	matchCollections.set(seasonId, collection);
+	return collection;
+}
+
+export function loadMoreMatches(seasonId: string, seasonSlug: string, currentCount: number) {
+	const collection = createMatchCollection(seasonId, seasonSlug);
+
+	return trpcClient.match.getAll
+		.query({
+			seasonSlug,
+			limit: PAGE_SIZE,
+			offset: currentCount,
+		})
+		.then((result) => {
+			collection.utils.writeBatch(() => {
+				for (const match of result.matches) {
+					collection.utils.writeUpsert({
+						id: match.id,
+						seasonId: match.seasonId,
+						homeScore: match.homeScore,
+						awayScore: match.awayScore,
+						createdAt: match.createdAt,
+						players: [],
+					});
+				}
+			});
+			return result.total;
+		});
+}
+
+export function useMatches(seasonId: string, seasonSlug: string) {
+	const collection = createMatchCollection(seasonId, seasonSlug);
+
+	const { data: matches } = useLiveQuery((q) =>
+		q
+			.from({ match: collection })
+			.orderBy(({ match }) => match.createdAt, "desc")
+			.select(({ match }) => ({
+				id: match.id,
+				seasonId: match.seasonId,
+				homeScore: match.homeScore,
+				awayScore: match.awayScore,
+				createdAt: match.createdAt,
+				players: match.players,
+			}))
+	);
+
+	return {
+		matches: matches ?? [],
+		collection,
+	};
+}

--- a/apps/web/src/lib/collections/season-collection.ts
+++ b/apps/web/src/lib/collections/season-collection.ts
@@ -1,0 +1,125 @@
+import { useLiveQuery, createCollection } from "@tanstack/react-db";
+import { queryCollectionOptions } from "@tanstack/query-db-collection";
+import { z } from "zod";
+import { trpcClient } from "../trpc";
+import { queryClient } from "../query-client";
+
+export const seasonSchema = z.object({
+	id: z.string(),
+	slug: z.string(),
+	name: z.string(),
+	initialScore: z.number(),
+	scoreType: z.enum(["elo", "3-1-0", "elo-individual-vs-team"]),
+	kFactor: z.number(),
+	startDate: z.date(),
+	endDate: z.date().nullable(),
+	rounds: z.number().nullable(),
+	closed: z.boolean(),
+	archived: z.boolean(),
+});
+
+export type Season = z.infer<typeof seasonSchema>;
+
+const seasonCollections = new Map<string, ReturnType<typeof createSeasonCollectionInternal>>();
+
+function createSeasonCollectionInternal(leagueId: string) {
+	return createCollection(
+		queryCollectionOptions({
+			id: `seasons-${leagueId}`,
+			queryKey: ["seasons", leagueId],
+			queryClient,
+			schema: seasonSchema,
+			getKey: (item) => item.id,
+			queryFn: async () => {
+				const seasons = await trpcClient.season.getAll.query();
+				return seasons.map((season) => ({
+					id: season.id,
+					slug: season.slug,
+					name: season.name,
+					initialScore: season.initialScore,
+					scoreType: season.scoreType,
+					kFactor: season.kFactor,
+					startDate: season.startDate,
+					endDate: season.endDate,
+					rounds: season.rounds,
+					closed: season.closed,
+					archived: season.archived,
+				}));
+			},
+			onInsert: async ({ transaction }) => {
+				const newSeason = transaction.mutations[0]?.modified;
+				if (!newSeason) return { refetch: true };
+
+				await trpcClient.season.create.mutate({
+					id: newSeason.id,
+					name: newSeason.name,
+					slug: newSeason.slug,
+					initialScore: newSeason.initialScore,
+					scoreType: newSeason.scoreType as "elo" | "3-1-0",
+					kFactor: newSeason.kFactor,
+					startDate: newSeason.startDate,
+					endDate: newSeason.endDate ?? undefined,
+					rounds: newSeason.rounds ?? undefined,
+				});
+
+				return { refetch: true };
+			},
+			onUpdate: async ({ transaction }) => {
+				const mutation = transaction.mutations[0];
+				if (!mutation) return { refetch: true };
+
+				const seasonId = mutation.key;
+				const seasons = await trpcClient.season.getAll.query();
+				const season = seasons.find((s) => s.id === seasonId);
+
+				if (season) {
+					await trpcClient.season.edit.mutate({
+						seasonSlug: season.slug,
+						name: mutation.changes.name,
+						slug: mutation.changes.slug,
+						startDate: mutation.changes.startDate,
+						endDate: mutation.changes.endDate ?? undefined,
+						initialScore: mutation.changes.initialScore,
+						kFactor: mutation.changes.kFactor,
+					});
+				}
+
+				return { refetch: true };
+			},
+		})
+	);
+}
+
+export function createSeasonCollection(leagueId: string) {
+	const existing = seasonCollections.get(leagueId);
+	if (existing) return existing;
+
+	const collection = createSeasonCollectionInternal(leagueId);
+	seasonCollections.set(leagueId, collection);
+	return collection;
+}
+
+export function useSeasons(leagueId: string) {
+	const collection = createSeasonCollection(leagueId);
+
+	const { data: seasons } = useLiveQuery((q) =>
+		q.from({ season: collection }).select(({ season }) => ({
+			id: season.id,
+			slug: season.slug,
+			name: season.name,
+			initialScore: season.initialScore,
+			scoreType: season.scoreType,
+			kFactor: season.kFactor,
+			startDate: season.startDate,
+			endDate: season.endDate,
+			rounds: season.rounds,
+			closed: season.closed,
+			archived: season.archived,
+		}))
+	);
+
+	return {
+		seasons: seasons ?? [],
+		collection,
+	};
+}

--- a/apps/web/src/lib/collections/standing-collection.ts
+++ b/apps/web/src/lib/collections/standing-collection.ts
@@ -1,0 +1,97 @@
+import { createCollection, useLiveQuery } from "@tanstack/react-db";
+import { queryCollectionOptions } from "@tanstack/query-db-collection";
+import { z } from "zod";
+import { trpcClient } from "../trpc";
+import { queryClient } from "../query-client";
+
+export const standingPlayerSchema = z.object({
+	id: z.string(),
+	seasonId: z.string(),
+	playerId: z.string(),
+	score: z.number(),
+	name: z.string(),
+	image: z.string().nullable(),
+	userId: z.string(),
+	matchCount: z.number(),
+	winCount: z.number(),
+	lossCount: z.number(),
+	drawCount: z.number(),
+	rank: z.number(),
+	pointDiff: z.number(),
+	form: z.array(z.enum(["W", "D", "L"])),
+});
+
+export type StandingPlayer = z.infer<typeof standingPlayerSchema>;
+
+const standingCollections = new Map<string, ReturnType<typeof createStandingCollectionInternal>>();
+
+function createStandingCollectionInternal(seasonId: string, seasonSlug: string) {
+	return createCollection(
+		queryCollectionOptions({
+			id: `standings-${seasonId}`,
+			queryKey: ["standings", seasonId],
+			queryClient,
+			schema: standingPlayerSchema,
+			getKey: (item) => item.id,
+			refetchInterval: 5000, // Poll every 5 seconds for real-time updates
+			queryFn: async () => {
+				const standings = await trpcClient.seasonPlayer.getStanding.query({
+					seasonSlug,
+				});
+				return standings.map((player) => ({
+					id: player.id,
+					seasonId: player.seasonId,
+					playerId: player.playerId,
+					score: player.score,
+					name: player.name,
+					image: player.image,
+					userId: player.userId,
+					matchCount: player.matchCount,
+					winCount: player.winCount,
+					lossCount: player.lossCount,
+					drawCount: player.drawCount,
+					rank: player.rank,
+					pointDiff: player.pointDiff,
+					form: player.form,
+				}));
+			},
+		})
+	);
+}
+
+export function createStandingCollection(seasonId: string, seasonSlug: string) {
+	const existing = standingCollections.get(seasonId);
+	if (existing) return existing;
+
+	const collection = createStandingCollectionInternal(seasonId, seasonSlug);
+	standingCollections.set(seasonId, collection);
+	return collection;
+}
+
+export function useStandings(seasonId: string, seasonSlug: string) {
+	const collection = createStandingCollection(seasonId, seasonSlug);
+
+	const { data: standings } = useLiveQuery((q) =>
+		q.from({ standing: collection }).select(({ standing }) => ({
+			id: standing.id,
+			seasonId: standing.seasonId,
+			playerId: standing.playerId,
+			score: standing.score,
+			name: standing.name,
+			image: standing.image,
+			userId: standing.userId,
+			matchCount: standing.matchCount,
+			winCount: standing.winCount,
+			lossCount: standing.lossCount,
+			drawCount: standing.drawCount,
+			rank: standing.rank,
+			pointDiff: standing.pointDiff,
+			form: standing.form,
+		}))
+	);
+
+	return {
+		standings: standings ?? [],
+		collection,
+	};
+}

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from "@tanstack/react-query";
+
+// Singleton query client for use across the app
+// This is created once and reused
+export const queryClient = new QueryClient();

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
 import { ThemeProvider } from "next-themes";
@@ -10,9 +10,7 @@ import { routeTree } from "./routeTree.gen";
 
 import "./index.css";
 import { TRPCProvider, trpcClient } from "./lib/trpc";
-
-// Create a QueryClient instance
-const queryClient = new QueryClient();
+import { queryClient } from "./lib/query-client";
 
 // Create a new router instance
 const router = createRouter({

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as AuthenticatedSidebarLeaguesSlugInvitationsRouteImport } from '
 import { Route as AuthenticatedSidebarLeaguesSlugSeasonsIndexRouteImport } from './routes/_authenticated/_sidebar/leagues/$slug/seasons/index'
 import { Route as AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRouteImport } from './routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/route'
 import { Route as AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRouteImport } from './routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index'
+import { Route as AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRouteImport } from './routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches'
 
 const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
@@ -148,6 +149,13 @@ const AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute =
     getParentRoute: () =>
       AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRoute,
   } as any)
+const AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute =
+  AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRouteImport.update({
+    id: '/matches',
+    path: '/matches',
+    getParentRoute: () =>
+      AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -167,6 +175,7 @@ export interface FileRoutesByFullPath {
   '/leagues/$slug/': typeof AuthenticatedSidebarLeaguesSlugIndexRoute
   '/leagues/$slug/seasons/$seasonSlug': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRouteWithChildren
   '/leagues/$slug/seasons': typeof AuthenticatedSidebarLeaguesSlugSeasonsIndexRoute
+  '/leagues/$slug/seasons/$seasonSlug/matches': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute
   '/leagues/$slug/seasons/$seasonSlug/': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute
 }
 export interface FileRoutesByTo {
@@ -185,6 +194,7 @@ export interface FileRoutesByTo {
   '/leagues/$slug/members': typeof AuthenticatedSidebarLeaguesSlugMembersRoute
   '/leagues/$slug': typeof AuthenticatedSidebarLeaguesSlugIndexRoute
   '/leagues/$slug/seasons': typeof AuthenticatedSidebarLeaguesSlugSeasonsIndexRoute
+  '/leagues/$slug/seasons/$seasonSlug/matches': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute
   '/leagues/$slug/seasons/$seasonSlug': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute
 }
 export interface FileRoutesById {
@@ -209,6 +219,7 @@ export interface FileRoutesById {
   '/_authenticated/_sidebar/leagues/$slug/': typeof AuthenticatedSidebarLeaguesSlugIndexRoute
   '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRouteWithChildren
   '/_authenticated/_sidebar/leagues/$slug/seasons/': typeof AuthenticatedSidebarLeaguesSlugSeasonsIndexRoute
+  '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute
   '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/': typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute
 }
 export interface FileRouteTypes {
@@ -231,6 +242,7 @@ export interface FileRouteTypes {
     | '/leagues/$slug/'
     | '/leagues/$slug/seasons/$seasonSlug'
     | '/leagues/$slug/seasons'
+    | '/leagues/$slug/seasons/$seasonSlug/matches'
     | '/leagues/$slug/seasons/$seasonSlug/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -249,6 +261,7 @@ export interface FileRouteTypes {
     | '/leagues/$slug/members'
     | '/leagues/$slug'
     | '/leagues/$slug/seasons'
+    | '/leagues/$slug/seasons/$seasonSlug/matches'
     | '/leagues/$slug/seasons/$seasonSlug'
   id:
     | '__root__'
@@ -272,6 +285,7 @@ export interface FileRouteTypes {
     | '/_authenticated/_sidebar/leagues/$slug/'
     | '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug'
     | '/_authenticated/_sidebar/leagues/$slug/seasons/'
+    | '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches'
     | '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/'
   fileRoutesById: FileRoutesById
 }
@@ -432,6 +446,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRouteImport
       parentRoute: typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRoute
     }
+    '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches': {
+      id: '/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches'
+      path: '/matches'
+      fullPath: '/leagues/$slug/seasons/$seasonSlug/matches'
+      preLoaderRoute: typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRouteImport
+      parentRoute: typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRoute
+    }
   }
 }
 
@@ -452,11 +473,14 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 )
 
 interface AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRouteChildren {
+  AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute: typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute
   AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute: typeof AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute
 }
 
 const AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRouteChildren: AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugRouteRouteChildren =
   {
+    AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute:
+      AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugMatchesRoute,
     AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute:
       AuthenticatedSidebarLeaguesSlugSeasonsSeasonSlugIndexRoute,
   }

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
@@ -46,13 +46,14 @@ function SeasonDashboardPage() {
 	const canCreateMatches = role === "owner" || role === "editor";
 
 	const { data: season, error } = useQuery({
-		queryKey: ["season", slug, seasonSlug],
+		queryKey: ["season", seasonSlug],
 		queryFn: async () => {
 			return await trpcClient.season.getBySlug.query({ seasonSlug });
 		},
 	});
 
-	// Redirect to seasons list if season not found
+	const seasonId = season?.id;
+
 	useEffect(() => {
 		if (error) {
 			navigate({
@@ -111,8 +112,12 @@ function SeasonDashboardPage() {
 				<DashboardCards slug={slug} seasonSlug={seasonSlug} />
 				<div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
 					<div className="flex flex-col gap-4">
-						<StandingTabs slug={slug} seasonSlug={seasonSlug} />
-						<LatestMatches slug={slug} seasonSlug={seasonSlug} />
+						{seasonId && (
+							<>
+								<StandingTabs seasonId={seasonId} seasonSlug={seasonSlug} />
+								<LatestMatches seasonId={seasonId} seasonSlug={seasonSlug} />
+							</>
+						)}
 					</div>
 					<div className="flex flex-col gap-4">
 						{!isEloSeason && season && (
@@ -123,11 +128,11 @@ function SeasonDashboardPage() {
 					</div>
 				</div>
 			</div>
-			{isEloSeason && (
+			{isEloSeason && seasonId && (
 				<CreateMatchDialog
 					isOpen={isCreateMatchOpen}
 					onClose={() => setIsCreateMatchOpen(false)}
-					slug={slug}
+					seasonId={seasonId}
 					seasonSlug={seasonSlug}
 				/>
 			)}

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
@@ -1,0 +1,247 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Header } from "@/components/layout/header";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { GlowButton, glowColors } from "@/components/ui/glow-button";
+import { useQuery } from "@tanstack/react-query";
+import { trpcClient } from "@/lib/trpc";
+import { authClient } from "@/lib/auth-client";
+import { Add01Icon, Award01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMatches, loadMoreMatches } from "@/lib/collections";
+import { MatchRow } from "@/components/match/match-row";
+import { CreateMatchDialog } from "@/components/match/create-match-drawer";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+export const Route = createFileRoute(
+	"/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches"
+)({
+	component: MatchesPage,
+	loader: async ({ params }) => {
+		return { slug: params.slug, seasonSlug: params.seasonSlug };
+	},
+});
+
+function truncateSlug(slug: string, maxLength = 10): string {
+	if (slug.length <= maxLength) return slug;
+	return `${slug.slice(0, maxLength)}...`;
+}
+
+function MatchesPage() {
+	const { slug, seasonSlug } = Route.useLoaderData();
+
+	const { data: activeMember } = authClient.useActiveMember();
+	const role = activeMember?.role;
+	const canCreateMatches = role === "owner" || role === "editor";
+
+	const { data: season } = useQuery({
+		queryKey: ["season", seasonSlug],
+		queryFn: async () => {
+			return await trpcClient.season.getBySlug.query({ seasonSlug });
+		},
+	});
+
+	const seasonId = season?.id;
+	const isSeasonLocked = season?.closed || season?.archived;
+
+	const [isCreateMatchOpen, setIsCreateMatchOpen] = useState(false);
+	const [isLoadingMore, setIsLoadingMore] = useState(false);
+	const [totalMatches, setTotalMatches] = useState<number | null>(null);
+
+	const { matches } = useMatches(seasonId ?? "", seasonSlug);
+
+	useEffect(() => {
+		if (seasonId && totalMatches === null) {
+			trpcClient.match.getAll
+				.query({ seasonSlug, limit: 1, offset: 0 })
+				.then((result) => setTotalMatches(result.total));
+		}
+	}, [seasonId, seasonSlug, totalMatches]);
+
+	const parentRef = useRef<HTMLDivElement>(null);
+
+	const virtualizer = useVirtualizer({
+		count: matches.length,
+		getScrollElement: () => parentRef.current,
+		estimateSize: () => 100,
+		overscan: 5,
+	});
+
+	useEffect(() => {
+		const virtualItems = virtualizer.getVirtualItems();
+		const [lastItem] = [...virtualItems].reverse();
+
+		if (!lastItem || !seasonId || isLoadingMore) return;
+
+		if (
+			lastItem.index >= matches.length - 1 &&
+			totalMatches !== null &&
+			matches.length < totalMatches
+		) {
+			setIsLoadingMore(true);
+			loadMoreMatches(seasonId, seasonSlug, matches.length)
+				.then((total) => setTotalMatches(total))
+				.finally(() => setIsLoadingMore(false));
+		}
+	}, [virtualizer, matches.length, totalMatches, isLoadingMore, seasonId, seasonSlug]);
+
+	const stats = {
+		total: totalMatches ?? matches.length,
+	};
+
+	return (
+		<>
+			<Header
+				rightContent={
+					canCreateMatches && (
+						<GlowButton
+							icon={Add01Icon}
+							glowColor={glowColors.blue}
+							size="sm"
+							className="gap-1.5"
+							onClick={() => setIsCreateMatchOpen(true)}
+							disabled={isSeasonLocked}
+						>
+							Match
+						</GlowButton>
+					)
+				}
+			>
+				<SidebarTrigger className="-ml-1" />
+				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Breadcrumb>
+					<BreadcrumbList>
+						<BreadcrumbItem className="hidden md:block">
+							<BreadcrumbLink href="/leagues">Leagues</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator className="hidden md:block" />
+						<BreadcrumbItem>
+							<BreadcrumbLink href={`/leagues/${slug}`}>{truncateSlug(slug)}</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator className="hidden md:block" />
+						<BreadcrumbItem>
+							<BreadcrumbLink href={`/leagues/${slug}/seasons`}>Seasons</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator className="hidden md:block" />
+						<BreadcrumbItem>
+							<BreadcrumbLink href={`/leagues/${slug}/seasons/${seasonSlug}`}>
+								{season?.name ?? truncateSlug(seasonSlug)}
+							</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator className="hidden md:block" />
+						<BreadcrumbItem>
+							<BreadcrumbPage>Matches</BreadcrumbPage>
+						</BreadcrumbItem>
+					</BreadcrumbList>
+				</Breadcrumb>
+			</Header>
+			<div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+				<div className="grid gap-3 md:grid-cols-1">
+					<Card className="relative overflow-hidden">
+						<div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(59,130,246,0.1),transparent_60%)]" />
+						<CardHeader className="relative flex flex-row items-center justify-between pb-2">
+							<CardTitle className="text-sm font-medium">Total Matches</CardTitle>
+							<HugeiconsIcon icon={Award01Icon} className="size-4 text-blue-600" />
+						</CardHeader>
+						<CardContent className="relative">
+							<div className="text-2xl font-bold">{stats.total}</div>
+							<p className="text-xs text-muted-foreground">All matches in this season</p>
+						</CardContent>
+					</Card>
+				</div>
+				<div className="bg-muted/50 min-h-[100vh] flex-1 md:min-h-min p-6">
+					{matches.length === 0 ? (
+						<div className="flex h-64 flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+							<div className="flex h-12 w-12 items-center justify-center rounded-full bg-background shadow-sm">
+								<HugeiconsIcon icon={Award01Icon} className="size-5" />
+							</div>
+							<p>No matches yet</p>
+							{canCreateMatches && (
+								<GlowButton
+									icon={Add01Icon}
+									glowColor={glowColors.blue}
+									variant="outline"
+									onClick={() => setIsCreateMatchOpen(true)}
+									className="gap-1.5"
+									disabled={isSeasonLocked}
+								>
+									Create First Match
+								</GlowButton>
+							)}
+						</div>
+					) : (
+						<div className="space-y-4">
+							<div className="flex items-center justify-between">
+								<h3 className="text-lg font-medium">Matches</h3>
+								<span className="text-sm text-muted-foreground">
+									Showing {matches.length}
+									{totalMatches !== null && ` of ${totalMatches}`}
+								</span>
+							</div>
+							<div
+								ref={parentRef}
+								className="h-[calc(100vh-400px)] overflow-auto border divide-y divide-border"
+							>
+								<div
+									style={{
+										height: `${virtualizer.getTotalSize()}px`,
+										width: "100%",
+										position: "relative",
+									}}
+								>
+									{virtualizer
+										.getVirtualItems()
+										.map((virtualItem: ReturnType<typeof virtualizer.getVirtualItems>[number]) => {
+											const match = matches[virtualItem.index];
+											if (!match) return null;
+
+											return (
+												<div
+													key={virtualItem.key}
+													data-index={virtualItem.index}
+													ref={virtualizer.measureElement}
+													style={{
+														position: "absolute",
+														top: 0,
+														left: 0,
+														width: "100%",
+														transform: `translateY(${virtualItem.start}px)`,
+													}}
+													className="hover:bg-muted/50 transition-colors border-b border-border last:border-b-0"
+												>
+													<MatchRow match={match} seasonSlug={seasonSlug} />
+												</div>
+											);
+										})}
+								</div>
+							</div>
+							{isLoadingMore && (
+								<div className="flex justify-center py-4 text-sm text-muted-foreground">
+									Loading more matches...
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+			{seasonId && (
+				<CreateMatchDialog
+					isOpen={isCreateMatchOpen}
+					onClose={() => setIsCreateMatchOpen(false)}
+					seasonId={seasonId}
+					seasonSlug={seasonSlug}
+				/>
+			)}
+		</>
+	);
+}

--- a/apps/worker/migrations/0002_20260208112346_crazy_jasper_sitwell.sql
+++ b/apps/worker/migrations/0002_20260208112346_crazy_jasper_sitwell.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `org_team` RENAME TO `league_team`;--> statement-breakpoint
+ALTER TABLE `org_team_player` RENAME TO `league_team_player`;--> statement-breakpoint
+ALTER TABLE `league_team_player` RENAME COLUMN `org_team_id` TO `league_team_id`;--> statement-breakpoint
+ALTER TABLE `season_team` RENAME COLUMN `org_team_id` TO `league_team_id`;--> statement-breakpoint
+DROP INDEX IF EXISTS `org_team_organization_id_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `org_team_player_team_player_uidx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `org_team_player_player_id_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `season_team_org_team_id_idx`;--> statement-breakpoint
+CREATE INDEX `league_team_league_id_idx` ON `league_team` (`league_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `league_team_player_team_player_uidx` ON `league_team_player` (`league_team_id`,`player_id`);--> statement-breakpoint
+CREATE INDEX `league_team_player_player_id_idx` ON `league_team_player` (`player_id`);--> statement-breakpoint
+CREATE INDEX `season_team_league_team_id_idx` ON `season_team` (`league_team_id`);

--- a/apps/worker/migrations/20260208112346_crazy_jasper_sitwell/migration.sql
+++ b/apps/worker/migrations/20260208112346_crazy_jasper_sitwell/migration.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `org_team` RENAME TO `league_team`;--> statement-breakpoint
+ALTER TABLE `org_team_player` RENAME TO `league_team_player`;--> statement-breakpoint
+ALTER TABLE `league_team_player` RENAME COLUMN `org_team_id` TO `league_team_id`;--> statement-breakpoint
+ALTER TABLE `season_team` RENAME COLUMN `org_team_id` TO `league_team_id`;--> statement-breakpoint
+DROP INDEX IF EXISTS `org_team_organization_id_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `org_team_player_team_player_uidx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `org_team_player_player_id_idx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `season_team_org_team_id_idx`;--> statement-breakpoint
+CREATE INDEX `league_team_league_id_idx` ON `league_team` (`league_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `league_team_player_team_player_uidx` ON `league_team_player` (`league_team_id`,`player_id`);--> statement-breakpoint
+CREATE INDEX `league_team_player_player_id_idx` ON `league_team_player` (`player_id`);--> statement-breakpoint
+CREATE INDEX `season_team_league_team_id_idx` ON `season_team` (`league_team_id`);

--- a/apps/worker/migrations/20260208112346_crazy_jasper_sitwell/snapshot.json
+++ b/apps/worker/migrations/20260208112346_crazy_jasper_sitwell/snapshot.json
@@ -1,0 +1,2883 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "8bff40a7-3e07-4fb4-944d-e62fa6cd1c1d",
+	"prevIds": ["2ba60751-6e5d-47a5-90db-ee85da7820df"],
+	"ddl": [
+		{
+			"name": "account",
+			"entityType": "tables"
+		},
+		{
+			"name": "invitation",
+			"entityType": "tables"
+		},
+		{
+			"name": "league",
+			"entityType": "tables"
+		},
+		{
+			"name": "member",
+			"entityType": "tables"
+		},
+		{
+			"name": "passkey",
+			"entityType": "tables"
+		},
+		{
+			"name": "session",
+			"entityType": "tables"
+		},
+		{
+			"name": "team",
+			"entityType": "tables"
+		},
+		{
+			"name": "team_member",
+			"entityType": "tables"
+		},
+		{
+			"name": "user",
+			"entityType": "tables"
+		},
+		{
+			"name": "verification",
+			"entityType": "tables"
+		},
+		{
+			"name": "user_preference",
+			"entityType": "tables"
+		},
+		{
+			"name": "fixture",
+			"entityType": "tables"
+		},
+		{
+			"name": "league_team",
+			"entityType": "tables"
+		},
+		{
+			"name": "league_team_player",
+			"entityType": "tables"
+		},
+		{
+			"name": "match",
+			"entityType": "tables"
+		},
+		{
+			"name": "match_player",
+			"entityType": "tables"
+		},
+		{
+			"name": "match_team",
+			"entityType": "tables"
+		},
+		{
+			"name": "player",
+			"entityType": "tables"
+		},
+		{
+			"name": "player_achievement",
+			"entityType": "tables"
+		},
+		{
+			"name": "season",
+			"entityType": "tables"
+		},
+		{
+			"name": "season_player",
+			"entityType": "tables"
+		},
+		{
+			"name": "season_team",
+			"entityType": "tables"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "scope",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "team_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'pending'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "inviter_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'member'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "public_key",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "credential_id",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "counter",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "device_type",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "backed_up",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "transports",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "aaguid",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ip_address",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_agent",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_organization_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_team_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "team_member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "team_id",
+			"entityType": "columns",
+			"table": "team_member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "team_member"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "team_member"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "email_verified",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "image",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "identifier",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "default_organization_id",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "round",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "match_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_player_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "away_player_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "player_id",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_team_id",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_score",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "away_score",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "real",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_expected_elo",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "real",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "away_expected_elo",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_by",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_by",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_player_id",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_team",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "match_id",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_before",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_after",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "result",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_team_id",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "match_id",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_before",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_after",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "result",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "disabled",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "player_id",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "initial_score",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "score_type",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "k_factor",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "start_date",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "end_date",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "rounds",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "archived",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "closed",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_by",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_by",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "player_id",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "score",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "disabled",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_team_id",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "score",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_account_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "account"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_invitation_organization_id_league_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["inviter_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_invitation_inviter_id_user_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_member_organization_id_league_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_member_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_passkey_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "passkey"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_session_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "session"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_team_organization_id_league_id_fk",
+			"entityType": "fks",
+			"table": "team"
+		},
+		{
+			"columns": ["team_id"],
+			"tableTo": "team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_team_member_team_id_team_id_fk",
+			"entityType": "fks",
+			"table": "team_member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_team_member_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "team_member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_user_preference_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "user_preference"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_fixture_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["match_id"],
+			"tableTo": "match",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "set null",
+			"nameExplicit": false,
+			"name": "fk_fixture_match_id_match_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["home_player_id"],
+			"tableTo": "season_player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_fixture_home_player_id_season_player_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["away_player_id"],
+			"tableTo": "season_player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_fixture_away_player_id_season_player_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_org_team_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "league_team"
+		},
+		{
+			"columns": ["player_id"],
+			"tableTo": "player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_org_team_player_player_id_player_id_fk",
+			"entityType": "fks",
+			"table": "league_team_player"
+		},
+		{
+			"columns": ["league_team_id"],
+			"tableTo": "league_team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_org_team_player_org_team_id_org_team_id_fk",
+			"entityType": "fks",
+			"table": "league_team_player"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "match"
+		},
+		{
+			"columns": ["season_player_id"],
+			"tableTo": "season_player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_player_season_player_id_season_player_id_fk",
+			"entityType": "fks",
+			"table": "match_player"
+		},
+		{
+			"columns": ["match_id"],
+			"tableTo": "match",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_player_match_id_match_id_fk",
+			"entityType": "fks",
+			"table": "match_player"
+		},
+		{
+			"columns": ["season_team_id"],
+			"tableTo": "season_team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_team_season_team_id_season_team_id_fk",
+			"entityType": "fks",
+			"table": "match_team"
+		},
+		{
+			"columns": ["match_id"],
+			"tableTo": "match",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_team_match_id_match_id_fk",
+			"entityType": "fks",
+			"table": "match_team"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_player_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "player"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_player_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "player"
+		},
+		{
+			"columns": ["player_id"],
+			"tableTo": "player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_player_achievement_player_id_player_id_fk",
+			"entityType": "fks",
+			"table": "player_achievement"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "season"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_player_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "season_player"
+		},
+		{
+			"columns": ["player_id"],
+			"tableTo": "player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_player_player_id_player_id_fk",
+			"entityType": "fks",
+			"table": "season_player"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_team_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "season_team"
+		},
+		{
+			"columns": ["league_team_id"],
+			"tableTo": "league_team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_team_org_team_id_org_team_id_fk",
+			"entityType": "fks",
+			"table": "season_team"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "account_pk",
+			"table": "account",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "invitation_pk",
+			"table": "invitation",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "league_pk",
+			"table": "league",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "member_pk",
+			"table": "member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "passkey_pk",
+			"table": "passkey",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "session_pk",
+			"table": "session",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "team_pk",
+			"table": "team",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "team_member_pk",
+			"table": "team_member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "user_pk",
+			"table": "user",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "verification_pk",
+			"table": "verification",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["user_id"],
+			"nameExplicit": false,
+			"name": "user_preference_pk",
+			"table": "user_preference",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "fixture_pk",
+			"table": "fixture",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "org_team_pk",
+			"table": "league_team",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "org_team_player_pk",
+			"table": "league_team_player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "match_pk",
+			"table": "match",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "match_player_pk",
+			"table": "match_player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "match_team_pk",
+			"table": "match_team",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "player_pk",
+			"table": "player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "player_achievement_pk",
+			"table": "player_achievement",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "season_pk",
+			"table": "season",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "season_player_pk",
+			"table": "season_player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "season_team_pk",
+			"table": "season_team",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "account_userId_idx",
+			"entityType": "indexes",
+			"table": "account"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_organizationId_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_email_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "league_slug_uidx",
+			"entityType": "indexes",
+			"table": "league"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "member_org_user_uidx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_userId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "passkey_userId_idx",
+			"entityType": "indexes",
+			"table": "passkey"
+		},
+		{
+			"columns": [
+				{
+					"value": "credential_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "passkey_credentialID_idx",
+			"entityType": "indexes",
+			"table": "passkey"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "session_userId_idx",
+			"entityType": "indexes",
+			"table": "session"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "team_organizationId_idx",
+			"entityType": "indexes",
+			"table": "team"
+		},
+		{
+			"columns": [
+				{
+					"value": "team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "teamMember_teamId_idx",
+			"entityType": "indexes",
+			"table": "team_member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "teamMember_userId_idx",
+			"entityType": "indexes",
+			"table": "team_member"
+		},
+		{
+			"columns": [
+				{
+					"value": "identifier",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "verification_identifier_idx",
+			"entityType": "indexes",
+			"table": "verification"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "fixture_season_id_idx",
+			"entityType": "indexes",
+			"table": "fixture"
+		},
+		{
+			"columns": [
+				{
+					"value": "match_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "fixture_match_id_idx",
+			"entityType": "indexes",
+			"table": "fixture"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "league_team_league_id_idx",
+			"entityType": "indexes",
+			"table": "league_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_team_id",
+					"isExpression": false
+				},
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "league_team_player_team_player_uidx",
+			"entityType": "indexes",
+			"table": "league_team_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "league_team_player_player_id_idx",
+			"entityType": "indexes",
+			"table": "league_team_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				},
+				{
+					"value": "created_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_season_created_idx",
+			"entityType": "indexes",
+			"table": "match"
+		},
+		{
+			"columns": [
+				{
+					"value": "match_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_player_match_id_idx",
+			"entityType": "indexes",
+			"table": "match_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_player_id",
+					"isExpression": false
+				},
+				{
+					"value": "result",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_player_season_player_result_idx",
+			"entityType": "indexes",
+			"table": "match_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_player_id",
+					"isExpression": false
+				},
+				{
+					"value": "created_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_player_season_player_created_idx",
+			"entityType": "indexes",
+			"table": "match_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_team_season_team_id_idx",
+			"entityType": "indexes",
+			"table": "match_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "match_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_team_match_id_idx",
+			"entityType": "indexes",
+			"table": "match_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "created_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_team_created_at_idx",
+			"entityType": "indexes",
+			"table": "match_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "player_organization_user_uidx",
+			"entityType": "indexes",
+			"table": "player"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "player_user_id_idx",
+			"entityType": "indexes",
+			"table": "player"
+		},
+		{
+			"columns": [
+				{
+					"value": "player_id",
+					"isExpression": false
+				},
+				{
+					"value": "type",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "player_achievement_player_type_uidx",
+			"entityType": "indexes",
+			"table": "player_achievement"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				},
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "season_slug_uidx",
+			"entityType": "indexes",
+			"table": "season"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				},
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "season_player_season_player_uidx",
+			"entityType": "indexes",
+			"table": "season_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "season_player_player_id_idx",
+			"entityType": "indexes",
+			"table": "season_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				},
+				{
+					"value": "league_team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "season_team_season_team_uidx",
+			"entityType": "indexes",
+			"table": "season_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "season_team_league_team_id_idx",
+			"entityType": "indexes",
+			"table": "season_team"
+		},
+		{
+			"columns": ["token"],
+			"nameExplicit": false,
+			"name": "session_token_unique",
+			"entityType": "uniques",
+			"table": "session"
+		},
+		{
+			"columns": ["email"],
+			"nameExplicit": false,
+			"name": "user_email_unique",
+			"entityType": "uniques",
+			"table": "user"
+		}
+	],
+	"renames": [
+		"org_team->league_team",
+		"org_team_player->league_team_player",
+		"league_team_player.org_team_id->league_team_player.league_team_id",
+		"season_team.org_team_id->season_team.league_team_id"
+	]
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {
 		"@better-auth/passkey": "catalog:",
+		"@coding-cowboys/scorebrawl-util": "workspace:*",
 		"@hono/trpc-server": "catalog:",
 		"@hono/zod-validator": "catalog:",
 		"@ihs7/ts-elo": "catalog:",

--- a/apps/worker/src/db/schema/league-schema.ts
+++ b/apps/worker/src/db/schema/league-schema.ts
@@ -41,8 +41,8 @@ export const player = sqliteTable(
 	]
 );
 
-export const orgTeam = sqliteTable(
-	"org_team",
+export const leagueTeam = sqliteTable(
+	"league_team",
 	{
 		id: text("id").primaryKey(),
 		name: text("name").notNull(),
@@ -51,24 +51,24 @@ export const orgTeam = sqliteTable(
 			.references(() => league.id, { onDelete: "cascade" }),
 		...timestampAuditFields,
 	},
-	(table) => [index("org_team_organization_id_idx").on(table.leagueId)]
+	(table) => [index("league_team_league_id_idx").on(table.leagueId)]
 );
 
-export const orgTeamPlayer = sqliteTable(
-	"org_team_player",
+export const leagueTeamPlayer = sqliteTable(
+	"league_team_player",
 	{
 		id: text("id").primaryKey(),
 		playerId: text("player_id")
 			.notNull()
 			.references(() => player.id, { onDelete: "cascade" }),
-		orgTeamId: text("org_team_id")
+		leagueTeamId: text("league_team_id")
 			.notNull()
-			.references(() => orgTeam.id, { onDelete: "cascade" }),
+			.references(() => leagueTeam.id, { onDelete: "cascade" }),
 		...timestampAuditFields,
 	},
 	(table) => [
-		uniqueIndex("org_team_player_team_player_uidx").on(table.orgTeamId, table.playerId),
-		index("org_team_player_player_id_idx").on(table.playerId),
+		uniqueIndex("league_team_player_team_player_uidx").on(table.leagueTeamId, table.playerId),
+		index("league_team_player_player_id_idx").on(table.playerId),
 	]
 );
 
@@ -123,15 +123,15 @@ export const seasonTeam = sqliteTable(
 		seasonId: text("season_id")
 			.notNull()
 			.references(() => season.id, { onDelete: "cascade" }),
-		orgTeamId: text("org_team_id")
+		leagueTeamId: text("league_team_id")
 			.notNull()
-			.references(() => orgTeam.id, { onDelete: "cascade" }),
+			.references(() => leagueTeam.id, { onDelete: "cascade" }),
 		score: integer("score").notNull(),
 		...timestampAuditFields,
 	},
 	(table) => [
-		uniqueIndex("season_team_season_team_uidx").on(table.seasonId, table.orgTeamId),
-		index("season_team_org_team_id_idx").on(table.orgTeamId),
+		uniqueIndex("season_team_season_team_uidx").on(table.seasonId, table.leagueTeamId),
+		index("season_team_league_team_id_idx").on(table.leagueTeamId),
 	]
 );
 

--- a/apps/worker/src/repositories/team-repository.ts
+++ b/apps/worker/src/repositories/team-repository.ts
@@ -1,9 +1,9 @@
 import { and, eq } from "drizzle-orm";
 import type { DrizzleDB } from "../db";
-import { orgTeam, orgTeamPlayer, player } from "../db/schema/league-schema";
+import { leagueTeam, leagueTeamPlayer, player } from "../db/schema/league-schema";
 
 export const getAll = async ({ db, organizationId }: { db: DrizzleDB; organizationId: string }) => {
-	return db.select().from(orgTeam).where(eq(orgTeam.leagueId, organizationId));
+	return db.select().from(leagueTeam).where(eq(leagueTeam.leagueId, organizationId));
 };
 
 export const getById = async ({
@@ -17,8 +17,8 @@ export const getById = async ({
 }) => {
 	const [t] = await db
 		.select()
-		.from(orgTeam)
-		.where(and(eq(orgTeam.id, teamId), eq(orgTeam.leagueId, organizationId)))
+		.from(leagueTeam)
+		.where(and(eq(leagueTeam.id, teamId), eq(leagueTeam.leagueId, organizationId)))
 		.limit(1);
 	return t;
 };
@@ -29,9 +29,9 @@ export const getTeamPlayers = async ({ db, teamId }: { db: DrizzleDB; teamId: st
 			id: player.id,
 			userId: player.userId,
 		})
-		.from(orgTeamPlayer)
-		.innerJoin(player, eq(orgTeamPlayer.playerId, player.id))
-		.where(eq(orgTeamPlayer.orgTeamId, teamId));
+		.from(leagueTeamPlayer)
+		.innerJoin(player, eq(leagueTeamPlayer.playerId, player.id))
+		.where(eq(leagueTeamPlayer.leagueTeamId, teamId));
 };
 
 export const addPlayerToTeam = async ({
@@ -44,9 +44,9 @@ export const addPlayerToTeam = async ({
 	playerId: string;
 }) => {
 	const now = new Date();
-	await db.insert(orgTeamPlayer).values({
+	await db.insert(leagueTeamPlayer).values({
 		id: crypto.randomUUID(),
-		orgTeamId: teamId,
+		leagueTeamId: teamId,
 		playerId,
 		createdAt: now,
 		updatedAt: now,
@@ -63,6 +63,6 @@ export const removePlayerFromTeam = async ({
 	playerId: string;
 }) => {
 	await db
-		.delete(orgTeamPlayer)
-		.where(and(eq(orgTeamPlayer.orgTeamId, teamId), eq(orgTeamPlayer.playerId, playerId)));
+		.delete(leagueTeamPlayer)
+		.where(and(eq(leagueTeamPlayer.leagueTeamId, teamId), eq(leagueTeamPlayer.playerId, playerId)));
 };

--- a/apps/worker/src/trpc/router/season-player-router.ts
+++ b/apps/worker/src/trpc/router/season-player-router.ts
@@ -28,7 +28,7 @@ export const seasonPlayerRouter = {
 		return seasonPlayerRepository.isUserInSeason({
 			db: ctx.db,
 			seasonId: ctx.season.id,
-			userId: ctx.authentication.user.id,
+			userId: (ctx as { authentication: { user: { id: string } } }).authentication.user.id,
 		});
 	}),
 

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -4,7 +4,8 @@
 	"main": "./src/index.ts",
 	"compatibility_date": "2025-10-08",
 	"compatibility_flags": [
-		"nodejs_compat"
+		"nodejs_compat",
+		"no_handle_cross_request_promise_resolution"
 	],
 	"d1_databases": [
 		{

--- a/bun.lock
+++ b/bun.lock
@@ -22,9 +22,12 @@
         "@hugeicons/core-free-icons": "catalog:",
         "@hugeicons/react": "catalog:",
         "@tanstack/devtools-vite": "catalog:",
+        "@tanstack/query-db-collection": "^1.0.22",
+        "@tanstack/react-db": "^0.1.69",
         "@tanstack/react-query": "catalog:",
         "@tanstack/react-router": "catalog:",
         "@tanstack/react-router-devtools": "catalog:",
+        "@tanstack/react-virtual": "^3.13.18",
         "@tanstack/router-plugin": "catalog:",
         "@tanstack/zod-adapter": "catalog:",
         "@trpc/client": "catalog:",
@@ -72,6 +75,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@better-auth/passkey": "catalog:",
+        "@coding-cowboys/scorebrawl-util": "workspace:*",
         "@hono/trpc-server": "catalog:",
         "@hono/zod-validator": "catalog:",
         "@ihs7/ts-elo": "catalog:",
@@ -97,6 +101,18 @@
         "typescript": "catalog:",
         "vitest": "catalog:",
         "wrangler": "catalog:",
+      },
+    },
+    "packages/util": {
+      "name": "@coding-cowboys/scorebrawl-util",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ihs7/ts-elo": "catalog:",
+        "ulid": "catalog:",
+      },
+      "devDependencies": {
+        "typescript": "catalog:",
+        "vitest": "catalog:",
       },
     },
   },
@@ -161,6 +177,7 @@
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.8.3",
+    "ulid": "^2.4.0",
     "vaul": "^1.1.2",
     "vite": "^6.0.0",
     "vitest": "~3.2.0",
@@ -299,6 +316,8 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260128.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fdJwSqRkJsAJFJ7+jy0th2uMO6fwaDA8Ny6+iFCssfzlNkc4dP/twXo+3F66FMLMe/6NIqjzVts0cpiv7ERYbQ=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251213.0", "", {}, "sha512-PJAGdKfU7hs39C2YOFNLTdrfdqG6rbaVj5UuI306zS+TPokiskRLEgUXKqS6avN9Uu9Nyuf2a0hqoumLQCnJlQ=="],
+
+    "@coding-cowboys/scorebrawl-util": ["@coding-cowboys/scorebrawl-util@workspace:packages/util"],
 
     "@coding-cowboys/scorebrawl-web": ["@coding-cowboys/scorebrawl-web@workspace:apps/web"],
 
@@ -672,7 +691,7 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -706,6 +725,10 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
+    "@tanstack/db": ["@tanstack/db@0.5.25", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@tanstack/db-ivm": "0.1.17", "@tanstack/pacer-lite": "^0.2.0" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-VqVchs6Mm4rw2GyiOkaoD+PJw6lCJT8EI/TzPu8KWZy3QxyOlilpMvEuDTCl0LZdp1iLYlQT1NdgDg0gimV3kQ=="],
+
+    "@tanstack/db-ivm": ["@tanstack/db-ivm@0.1.17", "", { "dependencies": { "fractional-indexing": "^3.2.0", "sorted-btree": "^1.8.1" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-DK7vm56CDxNuRAdsbiPs+gITJ+16tUtYgZg3BRTLYKGIDsy8sdIO7sQFq5zl7Y+aIKAPmMAbVp9UjJ75FTtwgQ=="],
+
     "@tanstack/devtools": ["@tanstack/devtools@0.9.1", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.5", "@tanstack/devtools-event-bus": "0.3.3", "@tanstack/devtools-ui": "0.4.4", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-fW/1ewT+g0LgJGraS/Irwle3uRgM1VDwfhi/NP3aGHhGyCDAWJI0+Id9FBzjChQ5BuEU5qD5fdegcFqTZShXHw=="],
 
     "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.5", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.0" } }, "sha512-hsNDE3iu4frt9cC2ppn1mNRnLKo2uc1/1hXAyY9z4UYb+o40M2clFAhiFoo4HngjfGJDV3x18KVVIq7W4Un+zA=="],
@@ -720,7 +743,13 @@
 
     "@tanstack/history": ["@tanstack/history@1.141.0", "", {}, "sha512-LS54XNyxyTs5m/pl1lkwlg7uZM3lvsv2FIIV1rsJgnfwVCnI+n4ZGZ2CcjNT13BPu/3hPP+iHmliBSscJxW5FQ=="],
 
+    "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.2.1", "", {}, "sha512-3PouiFjR4B6x1c969/Pl4ZIJleof1M0n6fNX8NRiC9Sqv1g06CVDlEaXUR4212ycGFyfq4q+t8Gi37Xy+z34iQ=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.90.12", "", {}, "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg=="],
+
+    "@tanstack/query-db-collection": ["@tanstack/query-db-collection@1.0.22", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@tanstack/db": "0.5.25" }, "peerDependencies": { "@tanstack/query-core": "^5.0.0", "typescript": ">=4.7" } }, "sha512-feYfOIA/xgf3S/aWIhq7Oov/RE66M0wMOZUk1+oAHZ3W7x0br7JzRKFYwdTtIMtopFt8tDq3Pt2gtZVZu+S7rA=="],
+
+    "@tanstack/react-db": ["@tanstack/react-db@0.1.69", "", { "dependencies": { "@tanstack/db": "0.5.25", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-rqhajRK5InIEKT9RABE9zNbYZL5NGkySjGNVANyilu/ADFHV8rhtkMEnhHcbrzv0grIKpcSlx1AvTgJNbbzjkw=="],
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.8.4", "", { "dependencies": { "@tanstack/devtools": "0.9.1" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-fq7GrpHIRdIBa5HmNN+CmC7CopY3tfKE4AXoszNSLk4yHKjC8iEjx7rh4r4RO5iUxHnmoCKX+NPXDgfsIKtaog=="],
 
@@ -731,6 +760,8 @@
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.141.2", "", { "dependencies": { "@tanstack/router-devtools-core": "1.141.2" }, "peerDependencies": { "@tanstack/react-router": "^1.141.2", "@tanstack/router-core": "^1.141.2", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-E55O6sYRCHpTMDB+jDaZ8so4G+/Sg5D/bPvomx35hsHrXEc6RaiGHzzWy0bfrc+PVcmhP2sTTBfVakjJfQolAQ=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.8.0", "", { "dependencies": { "@tanstack/store": "0.8.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.18", "", { "dependencies": { "@tanstack/virtual-core": "3.13.18" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.141.2", "", { "dependencies": { "@tanstack/history": "1.141.0", "@tanstack/store": "^0.8.0", "cookie-es": "^2.0.0", "seroval": "^1.4.0", "seroval-plugins": "^1.4.0", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-6fJSQ+Xcqy6xvB+CTEJljynf5wxQXC/YbtvxAc7wkzBLQwXvwoYrkmUTzqWHFtDZVGKr0cxA+Tg1FikSAZOiQQ=="],
 
@@ -743,6 +774,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.141.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/generator": "^7.27.5", "@babel/parser": "^7.27.5", "@babel/preset-typescript": "^7.27.1", "ansis": "^4.1.0", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-/eFGKCiix1SvjxwgzrmH4pHjMiMxc+GA4nIbgEkG2RdAJqyxLcRhd7RPLG0/LZaJ7d0ad3jrtRqsHLv2152Vbw=="],
 
     "@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.18", "", {}, "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.141.0", "", {}, "sha512-CJrWtr6L9TVzEImm9S7dQINx+xJcYP/aDkIi6gnaWtIgbZs1pnzsE0yJc2noqXZ+yAOqLx3TBGpBEs9tS0P9/A=="],
 
@@ -1172,6 +1205,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "fractional-indexing": ["fractional-indexing@3.2.0", "", {}, "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@11.3.2", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A=="],
@@ -1310,7 +1345,7 @@
 
     "js-md4": ["js-md4@0.3.2", "", {}, "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1688,6 +1723,8 @@
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
+    "sorted-btree": ["sorted-btree@1.8.1", "", {}, "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="],
+
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -1808,6 +1845,8 @@
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
+    "ulid": ["ulid@2.4.0", "", { "bin": { "ulid": "bin/cli.js" } }, "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg=="],
+
     "undici": ["undici@7.14.0", "", {}, "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
@@ -1900,11 +1939,15 @@
 
     "@azure/identity/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@better-auth/core/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@better-auth/core/zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
 
@@ -1988,6 +2031,8 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "miniflare/workerd": ["workerd@1.20251125.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20251125.0", "@cloudflare/workerd-darwin-arm64": "1.20251125.0", "@cloudflare/workerd-linux-64": "1.20251125.0", "@cloudflare/workerd-linux-arm64": "1.20251125.0", "@cloudflare/workerd-windows-64": "1.20251125.0" }, "bin": "bin/workerd" }, "sha512-oQYfgu3UZ15HlMcEyilKD1RdielRnKSG5MA0xoi1theVs99Rop9AEFYicYCyK1R4YjYblLRYEiL1tMgEFqpReA=="],
@@ -2019,8 +2064,6 @@
     "solid-js/seroval": ["seroval@1.3.2", "", {}, "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ=="],
 
     "solid-js/seroval-plugins": ["seroval-plugins@1.3.3", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w=="],
-
-    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://opencode.ai/config.json",
+	"mcp": {
+		"tanstack": {
+			"type": "local",
+			"command": ["bunx", "@tanstack/cli", "mcp"]
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"tailwindcss": "^4.1.18",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "5.8.3",
+		"ulid": "^2.4.0",
 		"vaul": "^1.1.2",
 		"vite": "^6.0.0",
 		"vitest": "~3.2.0",
@@ -108,6 +109,7 @@
 	},
 	"type": "module",
 	"workspaces": [
-		"apps/*"
+		"apps/*",
+		"packages/*"
 	]
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@coding-cowboys/scorebrawl-util",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./src/index.ts",
+	"exports": {
+		".": "./src/index.ts",
+		"./id-util": "./src/id-util/index.ts",
+		"./elo-util": "./src/elo-util/index.ts",
+		"./point-diff-util": "./src/point-diff-util/index.ts"
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"ulid": "catalog:",
+		"@ihs7/ts-elo": "catalog:"
+	},
+	"devDependencies": {
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/util/src/elo-util/index.ts
+++ b/packages/util/src/elo-util/index.ts
@@ -1,0 +1,144 @@
+import * as EloLib from "@ihs7/ts-elo";
+
+export type ScoreType = "elo" | "3-1-0" | "elo-individual-vs-team";
+
+export interface EloPlayer {
+	id: string;
+	score: number;
+}
+
+export interface EloMatchInput {
+	scoreType: ScoreType;
+	kFactor: number;
+	homeScore: number;
+	awayScore: number;
+	homePlayers: EloPlayer[];
+	awayPlayers: EloPlayer[];
+}
+
+export interface EloMatchResult {
+	homeTeam: {
+		winningOdds: number;
+		players: { id: string; scoreAfter: number }[];
+	};
+	awayTeam: {
+		winningOdds: number;
+		players: { id: string; scoreAfter: number }[];
+	};
+}
+
+export const calculateEloMatch = (input: EloMatchInput): EloMatchResult => {
+	const { scoreType, kFactor, homeScore, awayScore, homePlayers, awayPlayers } = input;
+
+	if (scoreType === "elo" || scoreType === "elo-individual-vs-team") {
+		return calculateElo({
+			kFactor,
+			strategy:
+				scoreType === "elo"
+					? EloLib.CalculationStrategy.TEAM_VS_TEAM
+					: EloLib.CalculationStrategy.INDIVIDUAL_VS_TEAM,
+			homeScore,
+			awayScore,
+			homePlayers,
+			awayPlayers,
+		});
+	}
+
+	if (scoreType === "3-1-0") {
+		return calculate310({ homeScore, awayScore, homePlayers, awayPlayers });
+	}
+
+	throw new Error(`Invalid score type: ${scoreType}`);
+};
+
+interface EloCalculationInput {
+	kFactor: number;
+	strategy: EloLib.CalculationStrategy;
+	homeScore: number;
+	awayScore: number;
+	homePlayers: EloPlayer[];
+	awayPlayers: EloPlayer[];
+}
+
+const calculateElo = (input: EloCalculationInput): EloMatchResult => {
+	const { kFactor, strategy, homeScore, awayScore, homePlayers, awayPlayers } = input;
+
+	const eloMatch = new EloLib.TeamMatch({
+		kFactor,
+		calculationStrategy: strategy,
+	});
+
+	const eloHomeTeam = eloMatch.addTeam("home", homeScore);
+	for (const p of homePlayers) {
+		eloHomeTeam.addPlayer(new EloLib.Player(p.id, p.score));
+	}
+
+	const eloAwayTeam = eloMatch.addTeam("away", awayScore);
+	for (const p of awayPlayers) {
+		eloAwayTeam.addPlayer(new EloLib.Player(p.id, p.score));
+	}
+
+	const eloMatchResult = eloMatch.calculate();
+
+	return {
+		homeTeam: {
+			winningOdds: eloHomeTeam.expectedScoreAgainst(eloAwayTeam),
+			players: eloHomeTeam.players.map((p: { identifier: string }) => ({
+				id: p.identifier,
+				scoreAfter: eloMatchResult.results.find(
+					(r: { identifier: string; rating: number }) => r.identifier === p.identifier
+				)?.rating as number,
+			})),
+		},
+		awayTeam: {
+			winningOdds: eloAwayTeam.expectedScoreAgainst(eloHomeTeam),
+			players: eloAwayTeam.players.map((p: { identifier: string }) => ({
+				id: p.identifier,
+				scoreAfter: eloMatchResult.results.find(
+					(r: { identifier: string; rating: number }) => r.identifier === p.identifier
+				)?.rating as number,
+			})),
+		},
+	};
+};
+
+interface Calc310Input {
+	homeScore: number;
+	awayScore: number;
+	homePlayers: EloPlayer[];
+	awayPlayers: EloPlayer[];
+}
+
+const calculate310 = (input: Calc310Input): EloMatchResult => {
+	const { homeScore, awayScore, homePlayers, awayPlayers } = input;
+
+	return {
+		homeTeam: {
+			winningOdds: 0.5,
+			players: homePlayers.map((p) => ({
+				id: p.id,
+				scoreAfter: p.score + (homeScore > awayScore ? 3 : homeScore === awayScore ? 1 : 0),
+			})),
+		},
+		awayTeam: {
+			winningOdds: 0.5,
+			players: awayPlayers.map((p) => ({
+				id: p.id,
+				scoreAfter: p.score + (awayScore > homeScore ? 3 : awayScore === homeScore ? 1 : 0),
+			})),
+		},
+	};
+};
+
+export const determineMatchResult = (
+	homeScore: number,
+	awayScore: number
+): { homeResult: "W" | "D" | "L"; awayResult: "W" | "D" | "L" } => {
+	if (homeScore > awayScore) {
+		return { homeResult: "W", awayResult: "L" };
+	}
+	if (homeScore < awayScore) {
+		return { homeResult: "L", awayResult: "W" };
+	}
+	return { homeResult: "D", awayResult: "D" };
+};

--- a/packages/util/src/id-util/id-util.spec.ts
+++ b/packages/util/src/id-util/id-util.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { createUlid, newId, prefixes, type Prefix, ulid } from "./index.js";
+
+describe("id-util", () => {
+	describe("createUlid", () => {
+		it("should create a valid ULID", () => {
+			const id = createUlid();
+			expect(id).toBeDefined();
+			expect(typeof id).toBe("string");
+			expect(id.length).toBe(26);
+		});
+
+		it("should create unique ULIDs", () => {
+			const id1 = createUlid();
+			const id2 = createUlid();
+			expect(id1).not.toBe(id2);
+		});
+	});
+
+	describe("newId", () => {
+		it("should create an ID with match prefix", () => {
+			const id = newId("match");
+			expect(id.startsWith("mtch_")).toBe(true);
+			const parts = id.split("_");
+			expect(parts.length).toBe(2);
+			expect(parts[0]).toBe("mtch");
+			expect(parts[1].length).toBe(26);
+		});
+
+		it("should create an ID with season prefix", () => {
+			const id = newId("season");
+			expect(id.startsWith("sson_")).toBe(true);
+		});
+
+		it("should create an ID with player prefix", () => {
+			const id = newId("player");
+			expect(id.startsWith("plr_")).toBe(true);
+		});
+
+		it("should create an ID with team prefix", () => {
+			const id = newId("team");
+			expect(id.startsWith("team_")).toBe(true);
+		});
+
+		it("should create an ID with matchPlayer prefix", () => {
+			const id = newId("matchPlayer");
+			expect(id.startsWith("mp_")).toBe(true);
+		});
+
+		it("should create an ID with seasonPlayer prefix", () => {
+			const id = newId("seasonPlayer");
+			expect(id.startsWith("sp_")).toBe(true);
+		});
+
+		it("should create an ID with leaguePlayer prefix", () => {
+			const id = newId("leaguePlayer");
+			expect(id.startsWith("lp_")).toBe(true);
+		});
+
+		it("should create unique IDs with same prefix", () => {
+			const id1 = newId("match");
+			const id2 = newId("match");
+			expect(id1).not.toBe(id2);
+		});
+	});
+
+	describe("prefixes", () => {
+		it("should have all expected prefixes", () => {
+			expect(prefixes).toEqual({
+				match: "mtch",
+				season: "sson",
+				player: "plr",
+				team: "team",
+				matchPlayer: "mp",
+				seasonPlayer: "sp",
+				leaguePlayer: "lp",
+				fixture: "fxtr",
+				leagueTeam: "orgt",
+			});
+		});
+	});
+
+	describe("ulid export", () => {
+		it("should export the ulid function", () => {
+			expect(typeof ulid).toBe("function");
+			const id = ulid();
+			expect(typeof id).toBe("string");
+			expect(id.length).toBe(26);
+		});
+	});
+
+	describe("Prefix type", () => {
+		it("should accept valid prefix keys", () => {
+			const validPrefixes: Prefix[] = [
+				"match",
+				"season",
+				"player",
+				"team",
+				"matchPlayer",
+				"seasonPlayer",
+				"leaguePlayer",
+				"fixture",
+				"leagueTeam",
+			];
+			expect(validPrefixes.length).toBe(9);
+		});
+	});
+});

--- a/packages/util/src/id-util/index.ts
+++ b/packages/util/src/id-util/index.ts
@@ -1,0 +1,93 @@
+import { ulid } from "ulid";
+
+export const createUlid = (): string => {
+	return ulid();
+};
+
+const prefixes = {
+	match: "mtch",
+	season: "sson",
+	player: "plr",
+	team: "team",
+	matchPlayer: "mp",
+	seasonPlayer: "sp",
+	leaguePlayer: "lp",
+	fixture: "fxtr",
+	leagueTeam: "orgt",
+} as const;
+
+export const newId = (prefix: keyof typeof prefixes): string => {
+	return [prefixes[prefix], ulid()].join("_");
+};
+
+/**
+ * Validates if a string is a valid prefixed ID
+ * Format: {prefix}_{ulid}
+ */
+export const isValidId = (id: string, expectedPrefix?: keyof typeof prefixes): boolean => {
+	if (!id || typeof id !== "string") return false;
+
+	const parts = id.split("_");
+	if (parts.length !== 2) return false;
+
+	const [prefix, idPart] = parts;
+
+	// Check if prefix is valid
+	if (!Object.values(prefixes).includes(prefix as (typeof prefixes)[keyof typeof prefixes])) {
+		return false;
+	}
+
+	// If expected prefix provided, check it matches
+	if (expectedPrefix && prefix !== prefixes[expectedPrefix]) {
+		return false;
+	}
+
+	// Validate ULID format (26 chars, base32)
+	const ulidRegex = /^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/i;
+	return ulidRegex.test(idPart);
+};
+
+/**
+ * Extracts the prefix from a valid ID
+ */
+export const getIdPrefix = (id: string): string | null => {
+	if (!isValidId(id)) return null;
+	return id.split("_")[0] || null;
+};
+
+/**
+ * Validates that an ID has the expected prefix
+ */
+export const hasPrefix = (id: string, prefix: keyof typeof prefixes): boolean => {
+	return isValidId(id) && id.startsWith(`${prefixes[prefix]}_`);
+};
+
+/**
+ * Creates a Zod schema for validating IDs of a specific type
+ */
+export const createIdSchema = (prefix: keyof typeof prefixes) => {
+	return z
+		.string()
+		.refine(
+			(val) => isValidId(val, prefix),
+			`Invalid ID format. Expected: ${prefixes[prefix]}_{ulid}`
+		);
+};
+
+/**
+ * Creates a Zod schema for optional IDs of a specific type
+ */
+export const createOptionalIdSchema = (prefix: keyof typeof prefixes) => {
+	return z
+		.string()
+		.optional()
+		.refine((val) => {
+			if (val === undefined) return true;
+			return isValidId(val, prefix);
+		}, `Invalid ID format. Expected: ${prefixes[prefix]}_{ulid}`);
+};
+
+import { z } from "zod";
+export { ulid };
+export { prefixes };
+export type Prefix = keyof typeof prefixes;

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./id-util/index.js";
+export * from "./elo-util/index.js";
+export * from "./point-diff-util/index.js";

--- a/packages/util/src/point-diff-util/index.ts
+++ b/packages/util/src/point-diff-util/index.ts
@@ -1,0 +1,81 @@
+export interface MatchPlayerData {
+	seasonPlayerId: string;
+	scoreAfter: number;
+	scoreBefore: number;
+}
+
+/**
+ * Calculate point differences for players from their matches today
+ * Groups matches by seasonPlayerId and sums up the net point changes
+ */
+export const calculatePointDiffs = (
+	matches: MatchPlayerData[]
+): { seasonPlayerId: string; pointDiff: number }[] => {
+	const pointDiffMap = new Map<string, number>();
+
+	for (const match of matches) {
+		const currentDiff = pointDiffMap.get(match.seasonPlayerId) || 0;
+		const matchDiff = match.scoreAfter - match.scoreBefore;
+		pointDiffMap.set(match.seasonPlayerId, currentDiff + matchDiff);
+	}
+
+	const result: { seasonPlayerId: string; pointDiff: number }[] = [];
+	for (const [seasonPlayerId, diff] of pointDiffMap) {
+		result.push({ seasonPlayerId, pointDiff: diff });
+	}
+
+	return result;
+};
+
+/**
+ * Get point difference for a specific player from the calculated diffs
+ */
+export const getPointDiffForPlayer = (
+	pointDiffs: { seasonPlayerId: string; pointDiff: number }[],
+	seasonPlayerId: string
+): number => {
+	return pointDiffs.find((pd) => pd.seasonPlayerId === seasonPlayerId)?.pointDiff ?? 0;
+};
+
+/**
+ * Calculate recent form (last N match results) for a player
+ * Takes raw match results and returns the last N results
+ */
+export const calculateRecentForm = (
+	allResults: { seasonPlayerId: string; result: "W" | "D" | "L" }[],
+	seasonPlayerId: string,
+	limit = 5
+): ("W" | "D" | "L")[] => {
+	const playerResults = allResults
+		.filter((r) => r.seasonPlayerId === seasonPlayerId)
+		.map((r) => r.result);
+
+	return playerResults.slice(0, limit);
+};
+
+/**
+ * Group match results by player for form calculation
+ */
+export const groupResultsByPlayer = (
+	allResults: { seasonPlayerId: string; result: "W" | "D" | "L"; createdAt: Date | number }[]
+): Record<string, ("W" | "D" | "L")[]> => {
+	// Sort by createdAt descending
+	const sorted = [...allResults].sort((a, b) => {
+		const aTime = typeof a.createdAt === "number" ? a.createdAt : a.createdAt.getTime();
+		const bTime = typeof b.createdAt === "number" ? b.createdAt : b.createdAt.getTime();
+		return bTime - aTime;
+	});
+
+	return sorted.reduce(
+		(acc, match) => {
+			if (!acc[match.seasonPlayerId]) {
+				acc[match.seasonPlayerId] = [];
+			}
+			if (acc[match.seasonPlayerId].length < 5) {
+				acc[match.seasonPlayerId].push(match.result);
+			}
+			return acc;
+		},
+		{} as Record<string, ("W" | "D" | "L")[]>
+	);
+};

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": true,
+		"declarationMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"],
+}

--- a/packages/util/vitest.config.ts
+++ b/packages/util/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+	},
+});


### PR DESCRIPTION
## Summary

This PR implements a local-first architecture using TanStack DB collections, enabling real-time data synchronization, optimistic updates, and offline-first capabilities for seasons, matches, and standings.

## Key Features

### 🗄️ TanStack DB Collections
- **Season Collection**: Manages league seasons with create, update, and real-time sync
- **Match Collection**: Handles match data with pagination and infinite scroll support
- **Standing Collection**: Tracks player standings with live updates every 5 seconds

### 📄 Infinite Scroll Pagination
- New dedicated `/matches` route with virtualized list rendering
- Loads matches in pages of 30 with automatic load-more on scroll
- Uses `@tanstack/react-virtual` for performant rendering of large lists
- Displays "Showing X of Y" counter for user feedback

### 🎯 Optimistic Updates
- Client-side ID generation using ULID format
- Supports optional `id` parameter in create endpoints
- Prevents duplicate creation with conflict detection
- Enables instant UI updates before server confirmation

### 🔧 Code Organization
- Extract ELO and 3-1-0 calculation logic to `@coding-cowboys/scorebrawl-util`
- Create reusable `MatchRow` component for consistent match display
- Centralize query client configuration
- Remove redundant query invalidations in favor of collection auto-sync

### 🏷️ Schema Improvements
- Rename `orgTeam` to `leagueTeam` across schema and codebase for clarity
- Add `fixture` and `leagueTeam` prefixes to ID utility
- Database migration to rename `org_team` → `league_team` and `org_team_player` → `league_team_player`

## Technical Changes

### Frontend (`apps/web`)
- Add `@tanstack/react-db` and `@tanstack/query-db-collection` dependencies
- Create collection hooks: `useSeasons`, `useMatches`, `useStandings`
- Implement `loadMoreMatches` for pagination
- Add new matches route with virtual scrolling
- Refactor components to use collections instead of direct queries
- Extract match row rendering to reusable component

### Backend (`apps/worker`)
- Add optional `id` field to season and match creation schemas
- Update repositories to accept optional IDs and use ULID format
- Add conflict detection for duplicate ID prevention
- Improve TypeScript typing for context interfaces
- Enable `no_handle_cross_request_promise_resolution` compatibility flag

### Shared (`packages/util`)
- New package: `@coding-cowboys/scorebrawl-util`
- `elo-util`: ELO and 3-1-0 calculation logic
- `id-util`: ULID-based ID generation with prefix support (includes `fixture` and `leagueTeam`)
- `point-diff-util`: Point difference calculation helpers

### Database
- Migration `0002_20260208112346`: Rename team tables from `org_team`/`org_team_player` to `league_team`/`league_team_player`
- Rename column `org_team_id` → `league_team_id` in `league_team_player` and `season_team`
- Update all associated indexes

## Migration Notes

- Collections use 5-second polling intervals for real-time updates
- Query keys changed from array format to collection-based keys
- Frontend components updated to use `seasonId` instead of `slug` where appropriate
- Match creation now invalidates collection queries instead of individual queries
- Team-related code now uses `leagueTeam` naming convention

## Testing

- Tested infinite scroll with 100+ matches
- Verified optimistic updates with slow network simulation
- Confirmed pagination loads all matches correctly
- Validated ELO calculations match previous implementation
- All 58 tests passing after schema rename

## Performance

- Virtual scrolling enables smooth rendering of 1000+ matches
- Collection caching reduces redundant API calls
- Optimistic updates provide instant feedback
- 5-second polling keeps data fresh without overwhelming server