### PR TITLE
fix: use tRPC queryOptions pattern and invalidate dashboard queries on SSE events

### DIFF
--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
@@ -121,7 +121,7 @@ function SeasonDashboardPage() {
 				</Breadcrumb>
 			</Header>
 			<div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-				<DashboardCards slug={slug} seasonSlug={seasonSlug} />
+				<DashboardCards seasonSlug={seasonSlug} />
 				<div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
 					<div className="flex flex-col gap-4">
 						{seasonId && (


### PR DESCRIPTION
## Summary

- Migrate dashboard card queries from manual `queryKey`/`queryFn` to `useTRPC().*.queryOptions()` for consistent cache key generation
- Invalidate tRPC dashboard queries (seasonPlayer.getTop, seasonPlayer.getAll, season.getCountInfo, match.getLatest) when SSE match events are received
- Add same query invalidations after match creation in the create-match drawer

## Changes

- **dashboard-cards.tsx**: Refactor all queries to use `trpc.*.queryOptions()`, remove unused `slug` prop, fix potential undefined in `getSideLabel`
- **create-match-drawer.tsx**: Use `useQueryClient()` hook, add comprehensive query invalidations for dashboard data refresh
- **use-season-sse.ts**: Invalidate tRPC queries when SSE events arrive so other browser tabs/users see updates

## Why

Previously, dashboard cards used inconsistent manual query keys that didn't match the tRPC-generated keys, causing stale data after match creation or SSE updates. This ensures real-time consistency across all connected clients.