### PR TITLE
feat: add match removal and improve sidebar active seasons UX

### DIFF
--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -17,7 +17,7 @@ export function Header({ children, includeLogoutButton = false, rightContent }: 
 	};
 
 	return (
-		<header className="sticky top-0 z-30 flex h-16 shrink-0 items-center justify-between gap-2 border-b bg-background px-4 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+		<header className="sticky top-0 z-30 flex h-12 shrink-0 items-center justify-between gap-2 border-b bg-background px-4 mb-4 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-10">
 			<div className="flex items-center gap-2">{children}</div>
 			<div className="flex items-center gap-2">
 				{rightContent}

--- a/apps/web/src/components/match/remove-match-dialog.tsx
+++ b/apps/web/src/components/match/remove-match-dialog.tsx
@@ -1,0 +1,176 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useTRPC } from "@/lib/trpc";
+import { queryClient } from "@/lib/query-client";
+import { Delete01Icon, Alert02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface RemoveMatchDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onSuccess?: () => void;
+	matchId: string | null;
+	seasonSlug: string;
+	seasonId: string;
+}
+
+export function RemoveMatchDialog({
+	isOpen,
+	onClose,
+	onSuccess,
+	matchId,
+	seasonSlug,
+	seasonId,
+}: RemoveMatchDialogProps) {
+	const trpc = useTRPC();
+	const [apiError, setApiError] = useState<string>("");
+
+	const removeMutation = useMutation({
+		...trpc.match.remove.mutationOptions(),
+		onSuccess: () => {
+			// Invalidate match and standings collections
+			queryClient.invalidateQueries({ queryKey: ["matches", seasonId] });
+			queryClient.invalidateQueries({ queryKey: ["standings", seasonId] });
+
+			// Invalidate tRPC queries
+			queryClient.invalidateQueries({
+				queryKey: trpc.seasonPlayer.getTop.queryKey({ seasonSlug }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: trpc.seasonPlayer.getAll.queryKey({ seasonSlug }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: trpc.seasonPlayer.getStanding.queryKey({ seasonSlug }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: trpc.season.getCountInfo.queryKey({ seasonSlug }),
+			});
+			queryClient.invalidateQueries({ queryKey: trpc.match.getLatest.queryKey({ seasonSlug }) });
+		},
+	});
+
+	const handleRemove = async () => {
+		setApiError("");
+
+		if (!matchId) return;
+
+		try {
+			await removeMutation.mutateAsync({
+				seasonSlug,
+				matchId,
+			});
+
+			toast.success("Match removed successfully");
+			onSuccess?.();
+			onClose();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to remove match";
+			setApiError(message);
+			toast.error(message);
+		}
+	};
+
+	const handleCancel = () => {
+		setApiError("");
+		onClose();
+	};
+
+	if (!matchId) return null;
+
+	return (
+		<Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
+			<DialogContent className="sm:max-w-md overflow-hidden">
+				{/* Technical Grid Background */}
+				<div className="absolute inset-0 opacity-[0.02] dark:opacity-[0.02] opacity-[0.05]">
+					<div
+						className="w-full h-full"
+						style={{
+							backgroundImage:
+								"radial-gradient(circle at 1px 1px, currentColor 1px, transparent 0)",
+							backgroundSize: "24px 24px",
+						}}
+					/>
+				</div>
+
+				{/* Header */}
+				<DialogHeader className="relative z-10 pb-4 border-b border-border">
+					<div className="flex items-center gap-3">
+						<div className="w-2 h-6 bg-red-500 rounded-full shadow-lg shadow-red-500/25" />
+						<DialogTitle className="text-xl font-bold font-mono tracking-tight">
+							Remove Match
+						</DialogTitle>
+					</div>
+				</DialogHeader>
+
+				<div className="relative z-10 space-y-4 py-4">
+					{/* Icon */}
+					<div className="flex justify-center">
+						<div className="w-16 h-16 rounded-full flex items-center justify-center bg-red-500/10">
+							<HugeiconsIcon icon={Delete01Icon} className="w-8 h-8 text-red-500" />
+						</div>
+					</div>
+
+					{/* Content */}
+					<div className="text-center space-y-2">
+						<h3 className="font-mono font-semibold text-lg">Remove Latest Match</h3>
+						<p className="text-muted-foreground text-sm">
+							Are you sure you want to remove the most recent match?
+						</p>
+					</div>
+
+					{/* Warning Box */}
+					<div className="border p-4 space-y-2 bg-red-500/10 border-red-500/20">
+						<div className="flex items-start gap-2">
+							<HugeiconsIcon
+								icon={Alert02Icon}
+								className="w-5 h-5 flex-shrink-0 mt-0.5 text-red-500"
+							/>
+							<div className="space-y-1">
+								<p className="text-xs text-muted-foreground">
+									This will revert all player and team scores to their previous values. This action
+									cannot be undone.
+								</p>
+							</div>
+						</div>
+					</div>
+
+					{/* Error Display */}
+					{apiError && (
+						<div className="rounded-lg bg-destructive/10 border border-destructive/20 p-3">
+							<p className="text-destructive font-mono text-xs">{apiError}</p>
+						</div>
+					)}
+
+					{/* Action Buttons */}
+					<div className="flex gap-3 pt-2">
+						<Button
+							variant="outline"
+							onClick={handleCancel}
+							className="flex-1 font-mono h-9 text-sm"
+						>
+							Cancel
+						</Button>
+						<Button
+							onClick={handleRemove}
+							disabled={removeMutation.isPending}
+							variant="destructive"
+							className="flex-1 font-mono font-bold h-9 text-sm"
+						>
+							{removeMutation.isPending ? (
+								"Removing..."
+							) : (
+								<>
+									<HugeiconsIcon icon={Delete01Icon} className="w-4 h-4 mr-2" />
+									Remove Match
+								</>
+							)}
+						</Button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/components/season/latest-matches.tsx
+++ b/apps/web/src/components/season/latest-matches.tsx
@@ -3,16 +3,18 @@ import { trpcClient } from "@/lib/trpc";
 import { OverviewCard } from "./overview-card";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { MatchRow } from "@/components/match/match-row";
-import { GlowButton, glowColors } from "@/components/ui/glow-button";
+import { Button } from "@/components/ui/button";
 import { Link, useParams } from "@tanstack/react-router";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 
 interface LatestMatchesProps {
 	seasonId: string;
 	seasonSlug: string;
+	canDelete?: boolean;
 }
 
-export function LatestMatches({ seasonId, seasonSlug }: LatestMatchesProps) {
+export function LatestMatches({ seasonId, seasonSlug, canDelete }: LatestMatchesProps) {
 	const params = useParams({ strict: false });
 	const slug = params.slug as string;
 
@@ -35,21 +37,21 @@ export function LatestMatches({ seasonId, seasonSlug }: LatestMatchesProps) {
 			action={
 				showMatches && (
 					<Link to="/leagues/$slug/seasons/$seasonSlug/matches" params={{ slug, seasonSlug }}>
-						<GlowButton
-							icon={ArrowRight01Icon}
-							glowColor={glowColors.amber}
-							size="sm"
-							variant="outline"
-							className="gap-1.5 whitespace-nowrap"
-						>
-							<span className="hidden sm:inline">View All</span>
-						</GlowButton>
+						<Button variant="outline" size="sm">
+							<span className="hidden sm:inline">See All</span>
+							<HugeiconsIcon icon={ArrowRight01Icon} className="h-4 w-4" />
+						</Button>
 					</Link>
 				)
 			}
 		>
 			{showMatches ? (
-				<MatchTable matches={latestMatches} seasonSlug={seasonSlug} />
+				<MatchTable
+					matches={latestMatches}
+					seasonSlug={seasonSlug}
+					seasonId={seasonId}
+					canDelete={canDelete}
+				/>
 			) : showEmptyState ? (
 				<div className="flex items-center justify-center h-40 text-muted-foreground">
 					No registered matches
@@ -62,17 +64,27 @@ export function LatestMatches({ seasonId, seasonSlug }: LatestMatchesProps) {
 function MatchTable({
 	matches,
 	seasonSlug,
+	seasonId,
+	canDelete,
 }: {
 	matches: { id: string; homeScore: number; awayScore: number; createdAt: Date }[];
 	seasonSlug: string;
+	seasonId: string;
+	canDelete?: boolean;
 }) {
 	return (
 		<Table>
 			<TableBody className="text-sm">
-				{matches.map((match) => (
+				{matches.map((match, index) => (
 					<TableRow key={match.id}>
 						<TableCell colSpan={3} className="p-0">
-							<MatchRow match={match} seasonSlug={seasonSlug} />
+							<MatchRow
+								match={match}
+								seasonSlug={seasonSlug}
+								seasonId={seasonId}
+								isLatest={index === 0}
+								canDelete={canDelete}
+							/>
 						</TableCell>
 					</TableRow>
 				))}

--- a/apps/web/src/components/sidebar/app-sidebar.tsx
+++ b/apps/web/src/components/sidebar/app-sidebar.tsx
@@ -3,7 +3,7 @@ import {
 	Award01Icon,
 	UserMultipleIcon,
 	Mail01Icon,
-	ArrowDown01Icon,
+	ArrowRight01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -22,16 +22,14 @@ import {
 	SidebarMenu,
 	SidebarMenuButton,
 	SidebarMenuItem,
+	SidebarMenuSub,
+	SidebarMenuSubButton,
+	SidebarMenuSubItem,
 	SidebarGroup,
 	SidebarGroupLabel,
 	useSidebar,
 } from "@/components/ui/sidebar";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { authClient } from "@/lib/auth-client";
 import { trpcClient } from "@/lib/trpc";
 
@@ -135,47 +133,56 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 					<SidebarGroup>
 						<SidebarGroupLabel>League</SidebarGroupLabel>
 						<SidebarMenu>
-							{activeSeasonCount > 0 && (
-								<SidebarMenuItem>
-									{hasMultipleActiveSeasons ? (
-										<DropdownMenu>
-											<DropdownMenuTrigger
-												render={
-													<SidebarMenuButton isActive={!!isActiveSeasonRoute}>
-														<HugeiconsIcon icon={Activity01Icon} className="size-4" />
-														<span>Active Seasons</span>
-														<HugeiconsIcon icon={ArrowDown01Icon} className="size-3 ml-auto" />
-													</SidebarMenuButton>
-												}
-											/>
-											<DropdownMenuContent align="start" className="w-48">
-												{activeSeasons?.map((season) => (
-													<DropdownMenuItem key={season.id} onClick={handleNavClick}>
-														<Link
-															to="/leagues/$slug/seasons/$seasonSlug"
-															params={{ slug: leagueSlug, seasonSlug: season.slug }}
-															className="flex items-center w-full"
-														>
-															{season.name}
-														</Link>
-													</DropdownMenuItem>
-												))}
-											</DropdownMenuContent>
-										</DropdownMenu>
-									) : (
+							{activeSeasonCount > 0 &&
+								(hasMultipleActiveSeasons ? (
+									<Collapsible defaultOpen={!!isActiveSeasonRoute} className="group/collapsible">
+										<SidebarMenuItem>
+											<SidebarMenuButton asChild isActive={!!isActiveSeasonRoute}>
+												<CollapsibleTrigger>
+													<HugeiconsIcon icon={Activity01Icon} className="size-4" />
+													<span>Active Seasons</span>
+													<HugeiconsIcon
+														icon={ArrowRight01Icon}
+														className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+													/>
+												</CollapsibleTrigger>
+											</SidebarMenuButton>
+											<CollapsibleContent>
+												<SidebarMenuSub>
+													{activeSeasons?.map((season) => (
+														<SidebarMenuSubItem key={season.id}>
+															<SidebarMenuSubButton asChild>
+																<Link
+																	to="/leagues/$slug/seasons/$seasonSlug"
+																	params={{ slug: leagueSlug, seasonSlug: season.slug }}
+																	onClick={handleNavClick}
+																>
+																	<span>{season.name}</span>
+																</Link>
+															</SidebarMenuSubButton>
+														</SidebarMenuSubItem>
+													))}
+												</SidebarMenuSub>
+											</CollapsibleContent>
+										</SidebarMenuItem>
+									</Collapsible>
+								) : (
+									<SidebarMenuItem>
 										<SidebarMenuButton asChild isActive={!!isActiveSeasonRoute}>
 											<Link
 												to="/leagues/$slug/seasons/$seasonSlug"
-												params={{ slug: leagueSlug, seasonSlug: singleActiveSeason!.slug }}
+												params={{
+													slug: leagueSlug,
+													seasonSlug: singleActiveSeason?.slug ?? "",
+												}}
 												onClick={handleNavClick}
 											>
 												<HugeiconsIcon icon={Activity01Icon} className="size-4" />
 												<span>Active Season</span>
 											</Link>
 										</SidebarMenuButton>
-									)}
-								</SidebarMenuItem>
-							)}
+									</SidebarMenuItem>
+								))}
 							<SidebarMenuItem>
 								<SidebarMenuButton asChild isActive={!!isSeasonsListRoute}>
 									<Link

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -12,7 +12,7 @@ function Separator({
       data-slot="separator"
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:h-4",
         className
       )}
       {...props}

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/invitations.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/invitations.tsx
@@ -287,7 +287,7 @@ function InvitationsPage() {
 				}
 			>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="hidden md:block">

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/members.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/members.tsx
@@ -240,7 +240,7 @@ function MembersPage() {
 			</Dialog>
 			<Header>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="hidden md:block">

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
@@ -104,7 +104,7 @@ function SeasonDashboardPage() {
 				}
 			>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="hidden md:block">
@@ -140,11 +140,23 @@ function SeasonDashboardPage() {
 						{hasTeams && seasonId ? (
 							<TeamStandingCard seasonId={seasonId} seasonSlug={seasonSlug} />
 						) : (
-							seasonId && <LatestMatches seasonId={seasonId} seasonSlug={seasonSlug} />
+							seasonId && (
+								<LatestMatches
+									seasonId={seasonId}
+									seasonSlug={seasonSlug}
+									canDelete={canCreateMatches && !isSeasonLocked}
+								/>
+							)
 						)}
 					</div>
 				</div>
-				{hasTeams && seasonId && <LatestMatches seasonId={seasonId} seasonSlug={seasonSlug} />}
+				{hasTeams && seasonId && (
+					<LatestMatches
+						seasonId={seasonId}
+						seasonSlug={seasonSlug}
+						canDelete={canCreateMatches && !isSeasonLocked}
+					/>
+				)}
 			</div>
 			{isEloSeason && seasonId && (
 				<CreateMatchDialog

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
@@ -43,6 +43,7 @@ function MatchesPage() {
 	const { data: activeMember } = authClient.useActiveMember();
 	const role = activeMember?.role;
 	const canCreateMatches = role === "owner" || role === "editor";
+	const canDeleteMatches = role === "owner" || role === "editor";
 
 	const { data: season } = useQuery({
 		queryKey: ["season", seasonSlug],
@@ -118,7 +119,7 @@ function MatchesPage() {
 				}
 			>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="hidden md:block">
@@ -219,7 +220,13 @@ function MatchesPage() {
 													}}
 													className="hover:bg-muted/50 transition-colors border-b border-border last:border-b-0"
 												>
-													<MatchRow match={match} seasonSlug={seasonSlug} />
+													<MatchRow
+														match={match}
+														seasonSlug={seasonSlug}
+														seasonId={seasonId ?? ""}
+														isLatest={virtualItem.index === 0}
+														canDelete={canDeleteMatches && !isSeasonLocked}
+													/>
 												</div>
 											);
 										})}

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/index.tsx
@@ -217,7 +217,7 @@ function SeasonsPage() {
 				}
 			>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="hidden md:block">

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/teams.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/teams.tsx
@@ -347,7 +347,7 @@ function TeamsPage() {
 
 			<Header>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="hidden md:block">

--- a/apps/web/src/routes/_authenticated/_sidebar/profile.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/profile.tsx
@@ -413,7 +413,7 @@ function ProfilePage() {
 		<>
 			<Header>
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+				<Separator orientation="vertical" className="mr-2" />
 				<h1 className="text-lg font-semibold">Profile</h1>
 			</Header>
 			<div className="flex flex-1 flex-col gap-6 p-6 pt-0">


### PR DESCRIPTION
## Summary

- Add ability to remove the most recent match from a season
- Improve sidebar navigation by replacing dropdown with collapsible for multiple active seasons

## Changes

### Match Removal Feature
- Add `RemoveMatchDialog` component with confirmation UI and warning about score reversal
- Add "Remove" button to `MatchRow` component (only visible for the latest match)
- Pass `seasonId`, `isLatest`, and `canDelete` props to `MatchRow` for conditional rendering
- Invalidate relevant queries (matches, standings, player stats) after successful removal

### Sidebar UX Improvement
- Replace `DropdownMenu` with shadcn's recommended `Collapsible` pattern for active seasons
- Use `SidebarMenuSub`, `SidebarMenuSubItem`, and `SidebarMenuSubButton` for nested navigation
- Add rotating chevron icon (`ArrowRight01Icon`) that animates on expand/collapse
- Auto-expand the collapsible when user is viewing an active season route
- Season sub-items display with indented layout and vertical line indicator

### Other
- Remove non-null assertion in favor of optional chaining with fallback
- Update imports and clean up unused dependencies

## Screenshots

The collapsible follows this pattern from shadcn/ui docs:
- Clicking "Active Seasons" expands/collapses the list inline
- Chevron rotates 90° when expanded
- Sub-items are indented with a connecting line on the left