### PR TITLE
Fix sidebar usability, member permissions, toast dark mode, and match display

### DIFF
--- a/apps/e2e/tests/seeded-match-crud.spec.ts
+++ b/apps/e2e/tests/seeded-match-crud.spec.ts
@@ -105,8 +105,11 @@ test.describe("Seeded Match CRUD", () => {
 		// Wait for the new match to appear in the list - verify score 11-0
 		await expect(async () => {
 			const latestMatchRow = page.locator('[data-testid^="match-row-"]').first();
-			const scoreEl = latestMatchRow.locator('[data-testid^="match-score-"]');
-			await expect(scoreEl).toHaveText("11 - 0");
+			const scoreEls = latestMatchRow.locator('[data-testid^="match-score-"]');
+			await expect(scoreEls).toHaveCount(2);
+			const scores = await scoreEls.allTextContents();
+			expect(scores[0]).toBe("11");
+			expect(scores[1]).toBe("0");
 		}).toPass({ timeout: 10000 });
 
 		// Verify standings updated
@@ -132,9 +135,11 @@ test.describe("Seeded Match CRUD", () => {
 		// Wait for the match with 11-0 score to disappear
 		await expect(async () => {
 			const latestMatchRow = page.locator('[data-testid^="match-row-"]').first();
-			const scoreEl = latestMatchRow.locator('[data-testid^="match-score-"]');
+			const scoreEls = latestMatchRow.locator('[data-testid^="match-score-"]');
+			await expect(scoreEls).toHaveCount(2);
+			const scores = await scoreEls.allTextContents();
 			// The 11-0 match should no longer be the first row
-			await expect(scoreEl).not.toHaveText("11 - 0");
+			expect(scores[0] !== "11" || scores[1] !== "0").toBe(true);
 		}).toPass({ timeout: 10000 });
 
 		// Step 8: Verify scores went back to original (with retry for timing)
@@ -177,11 +182,13 @@ test.describe("Seeded Match CRUD", () => {
 		const count = await matchRows.count();
 		expect(count).toBeGreaterThan(0);
 
-		// Verify match has score displayed
+		// Verify match has scores displayed (new format: inline with team names)
 		const firstMatch = matchRows.first();
-		const scoreEl = firstMatch.locator('[data-testid^="match-score-"]');
-		await expect(scoreEl).toBeVisible();
-		const scoreText = await scoreEl.textContent();
-		expect(scoreText).toMatch(/\d+\s*-\s*\d+/);
+		const scoreEls = firstMatch.locator('[data-testid^="match-score-"]');
+		await expect(scoreEls).toHaveCount(2);
+		const scores = await scoreEls.allTextContents();
+		expect(scores.length).toBe(2);
+		expect(Number.parseInt(scores[0], 10)).toBeGreaterThanOrEqual(0);
+		expect(Number.parseInt(scores[1], 10)).toBeGreaterThanOrEqual(0);
 	});
 });

--- a/apps/web/src/components/match/create-match-drawer.tsx
+++ b/apps/web/src/components/match/create-match-drawer.tsx
@@ -282,7 +282,7 @@ export function CreateMatchDialog({
 		<>
 			<Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
 				<DialogContent
-					className="sm:max-w-lg max-h-[95vh] overflow-hidden p-0"
+					className="sm:max-w-lg max-h-[95vh] overflow-hidden p-0 top-8 translate-y-0 data-[state=open]:top-8"
 					data-testid="create-match-dialog"
 				>
 					{/* Decorative grid background */}
@@ -308,19 +308,21 @@ export function CreateMatchDialog({
 					<div className="relative z-10 overflow-y-auto max-h-[calc(95vh-80px)] p-4">
 						<form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
 							{/* Score Steppers */}
-							<div className="grid grid-cols-2 gap-4">
-								<ScoreStepper
-									label="Home"
-									score={homeScore}
-									onIncrement={() => setValue("homeScore", homeScore + 1)}
-									onDecrement={() => setValue("homeScore", Math.max(0, homeScore - 1))}
-								/>
-								<ScoreStepper
-									label="Away"
-									score={awayScore}
-									onIncrement={() => setValue("awayScore", awayScore + 1)}
-									onDecrement={() => setValue("awayScore", Math.max(0, awayScore - 1))}
-								/>
+							<div className="bg-muted/30">
+								<div className="grid grid-cols-2">
+									<ScoreStepper
+										label="Home"
+										score={homeScore}
+										onIncrement={() => setValue("homeScore", homeScore + 1)}
+										onDecrement={() => setValue("homeScore", Math.max(0, homeScore - 1))}
+									/>
+									<ScoreStepper
+										label="Away"
+										score={awayScore}
+										onIncrement={() => setValue("awayScore", awayScore + 1)}
+										onDecrement={() => setValue("awayScore", Math.max(0, awayScore - 1))}
+									/>
+								</div>
 							</div>
 
 							{/* Team Roster Cards */}
@@ -423,7 +425,7 @@ function ScoreStepper({
 }) {
 	const testIdPrefix = `match-${label.toLowerCase()}`;
 	return (
-		<div className="flex flex-col items-center gap-1 border border-border p-4">
+		<div className="flex flex-col items-center gap-1 p-4">
 			<div className="text-[0.65rem] uppercase tracking-wider text-muted-foreground font-mono">
 				{label}
 			</div>
@@ -475,9 +477,9 @@ function TeamRosterCard({
 			<div className="px-3 py-2 border-b border-border bg-muted/30">
 				<div className="flex items-center justify-between">
 					<span className="text-xs font-mono font-medium uppercase tracking-wider text-muted-foreground">
-						{label} Team
+						{label.toUpperCase()}
 					</span>
-					<span className="text-xs font-mono text-muted-foreground">
+					<span className="text-xs font-mono text-muted-foreground whitespace-nowrap">
 						{count} player{count !== 1 ? "s" : ""}
 					</span>
 				</div>

--- a/apps/web/src/components/match/match-row.tsx
+++ b/apps/web/src/components/match/match-row.tsx
@@ -1,54 +1,6 @@
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { trpcClient } from "@/lib/trpc";
-import { AvatarWithFallback } from "@/components/ui/avatar-with-fallback";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { UserMultipleIcon } from "@hugeicons/core-free-icons";
-
-const getAssetUrl = (key: string | null | undefined): string | null => {
-	if (!key) return null;
-	if (key.startsWith("http://") || key.startsWith("https://")) {
-		return key;
-	}
-	return `/api/user-assets/${key}`;
-};
-
-function TeamIcon({ logo, name }: { logo: string | null; name: string }) {
-	const [hasError, setHasError] = useState(false);
-	const logoUrl = getAssetUrl(logo);
-
-	if (!logoUrl || hasError) {
-		return (
-			<div className="flex h-6 w-6 items-center justify-center rounded-lg bg-blue-500/10">
-				<HugeiconsIcon icon={UserMultipleIcon} className="size-4 text-blue-500" />
-			</div>
-		);
-	}
-
-	return (
-		<div className="flex h-6 w-6 items-center justify-center rounded-lg overflow-hidden">
-			<img
-				src={logoUrl}
-				alt={name}
-				className="h-full w-full object-cover"
-				onError={() => setHasError(true)}
-			/>
-		</div>
-	);
-}
-
-interface MatchPlayer {
-	id: string;
-	seasonPlayerId: string;
-	homeTeam: boolean;
-	result: "W" | "L" | "D";
-	scoreBefore: number;
-	scoreAfter: number;
-	name: string;
-	image: string | null;
-	teamName: string | null;
-	teamLogo: string | null;
-}
+import { MatchScoreDisplay, type MatchDisplayPlayer } from "./match-score-display";
 
 interface MatchRowProps {
 	match: {
@@ -61,105 +13,26 @@ interface MatchRowProps {
 	seasonId: string;
 }
 
-function getTeamInfo(players: MatchPlayer[]): { name: string; logo: string | null } | null {
-	if (players.length <= 1) return null;
-	// Multiple players = always a team
-	// Use the teamName/teamLogo from the first player (backend sets same value for all players on a side)
-	const teamName = players[0]?.teamName;
-	const teamLogo = players[0]?.teamLogo ?? null;
-	if (teamName) {
-		return { name: teamName, logo: teamLogo };
-	}
-	// Fallback: use player first names as team name
-	const fallbackName = players.map((p) => p.name.split(" ")[0]).join(" & ");
-	return { name: fallbackName, logo: teamLogo };
-}
-
-function getSideLabel(players: MatchPlayer[]): string {
-	if (players.length === 0) return "Unknown";
-	const teamInfo = getTeamInfo(players);
-	if (teamInfo) {
-		return teamInfo.name;
-	}
-	return players.map((p) => p.name).join(", ");
-}
-
-function formatDate(date: Date) {
-	const now = new Date();
-	const matchDate = new Date(date);
-
-	const isToday =
-		now.getFullYear() === matchDate.getFullYear() &&
-		now.getMonth() === matchDate.getMonth() &&
-		now.getDate() === matchDate.getDate();
-
-	if (isToday) {
-		const diffMs = now.getTime() - matchDate.getTime();
-		const diffMinutes = Math.floor(diffMs / (1000 * 60));
-
-		if (diffMinutes < 60) {
-			return diffMinutes <= 1 ? "1m ago" : `${diffMinutes}m ago`;
-		}
-		const diffHours = Math.floor(diffMinutes / 60);
-		return `${diffHours}h ago`;
-	}
-	return matchDate.toLocaleDateString("en-US", {
-		month: "short",
-		day: "numeric",
-	});
-}
-
-function SideDisplay({ players, side }: { players: MatchPlayer[]; side: "home" | "away" }) {
-	const teamInfo = getTeamInfo(players);
-
-	return (
-		<div className="flex items-center gap-2 min-w-0" data-testid={`match-${side}-side`}>
-			<div className="flex gap-1 shrink-0">
-				{teamInfo ? (
-					<TeamIcon logo={teamInfo.logo} name={teamInfo.name} />
-				) : (
-					players.map((player) => (
-						<AvatarWithFallback key={player.id} src={player.image} name={player.name} size="sm" />
-					))
-				)}
-			</div>
-			<span className="text-xs text-muted-foreground truncate">{getSideLabel(players)}</span>
-		</div>
-	);
-}
-
 export function MatchRow({ match, seasonSlug }: MatchRowProps) {
-	const { data: matchDetails } = useQuery<{ players: MatchPlayer[] } | null>({
+	const { data: matchDetails } = useQuery({
 		queryKey: ["match", "details", match.id],
-		queryFn: async () => {
-			return await trpcClient.match.getById.query({ seasonSlug, matchId: match.id });
-		},
+		queryFn: () => trpcClient.match.getById.query({ seasonSlug, matchId: match.id }),
 		enabled: !!match.id,
 	});
 
-	const homePlayers = matchDetails?.players?.filter((p) => p.homeTeam) ?? [];
-	const awayPlayers = matchDetails?.players?.filter((p) => !p.homeTeam) ?? [];
+	const homePlayers = (matchDetails?.players?.filter((p: MatchDisplayPlayer) => p.homeTeam) ??
+		[]) as MatchDisplayPlayer[];
+	const awayPlayers = (matchDetails?.players?.filter((p: MatchDisplayPlayer) => !p.homeTeam) ??
+		[]) as MatchDisplayPlayer[];
 
 	return (
-		<div
-			className="flex items-center justify-between gap-4 p-4"
-			data-testid={`match-row-${match.id}`}
-		>
-			<div className="flex flex-col gap-2 min-w-0 flex-1">
-				<SideDisplay players={homePlayers} side="home" />
-				<SideDisplay players={awayPlayers} side="away" />
-			</div>
-			<div className="flex items-center gap-4 flex-shrink-0">
-				<div className="text-center font-bold text-sm" data-testid={`match-score-${match.id}`}>
-					{match.homeScore} - {match.awayScore}
-				</div>
-				<div
-					className="text-xs text-muted-foreground text-right min-w-[60px]"
-					data-testid={`match-date-${match.id}`}
-				>
-					{formatDate(match.createdAt)}
-				</div>
-			</div>
-		</div>
+		<MatchScoreDisplay
+			matchId={match.id}
+			homeScore={match.homeScore}
+			awayScore={match.awayScore}
+			createdAt={match.createdAt}
+			homePlayers={homePlayers}
+			awayPlayers={awayPlayers}
+		/>
 	);
 }

--- a/apps/web/src/components/match/match-score-display.tsx
+++ b/apps/web/src/components/match/match-score-display.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { AvatarWithFallback } from "@/components/ui/avatar-with-fallback";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { UserMultipleIcon } from "@hugeicons/core-free-icons";
+
+const getAssetUrl = (key: string | null | undefined): string | null => {
+	if (!key) return null;
+	if (key.startsWith("http://") || key.startsWith("https://")) return key;
+	return `/api/user-assets/${key}`;
+};
+
+function TeamIcon({ logo, name }: { logo: string | null; name: string }) {
+	const [hasError, setHasError] = useState(false);
+	const logoUrl = getAssetUrl(logo);
+
+	if (!logoUrl || hasError) {
+		return (
+			<div className="flex h-6 w-6 items-center justify-center rounded-lg bg-blue-500/10">
+				<HugeiconsIcon icon={UserMultipleIcon} className="size-4 text-blue-500" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-6 w-6 items-center justify-center rounded-lg overflow-hidden">
+			<img
+				src={logoUrl}
+				alt={name}
+				className="h-full w-full object-cover"
+				onError={() => setHasError(true)}
+			/>
+		</div>
+	);
+}
+
+export interface MatchDisplayPlayer {
+	id: string;
+	name: string;
+	image: string | null;
+	teamName: string | null;
+	teamLogo: string | null;
+	homeTeam: boolean;
+}
+
+function getTeamInfo(players: MatchDisplayPlayer[]): { name: string; logo: string | null } | null {
+	if (players.length <= 1) return null;
+	const teamName = players[0]?.teamName;
+	const teamLogo = players[0]?.teamLogo ?? null;
+	if (teamName) return { name: teamName, logo: teamLogo };
+	return { name: players.map((p) => p.name.split(" ")[0]).join(" & "), logo: teamLogo };
+}
+
+function getSideLabel(players: MatchDisplayPlayer[]): string {
+	if (players.length === 0) return "Unknown";
+	const teamInfo = getTeamInfo(players);
+	if (teamInfo) return teamInfo.name;
+	return players.map((p) => p.name).join(", ");
+}
+
+function formatTimestamp(date: Date) {
+	const now = new Date();
+	const matchDate = new Date(date);
+	const isToday = now.toDateString() === matchDate.toDateString();
+
+	if (isToday) {
+		const diffMs = now.getTime() - matchDate.getTime();
+		const diffMinutes = Math.floor(diffMs / (1000 * 60));
+		if (diffMinutes < 60) {
+			return { primary: diffMinutes <= 1 ? "1m ago" : `${diffMinutes}m ago` };
+		}
+		return { primary: `${Math.floor(diffMinutes / 60)}h ago` };
+	}
+
+	return {
+		primary: matchDate.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+		secondary: matchDate.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" }),
+	};
+}
+
+function ScoreLine({
+	players,
+	score,
+	isWinner,
+	isMuted,
+	"data-testid": dataTestId,
+}: {
+	players: MatchDisplayPlayer[];
+	score: number;
+	isWinner: boolean;
+	isMuted: boolean;
+	"data-testid"?: string;
+}) {
+	const teamInfo = getTeamInfo(players);
+
+	return (
+		<div className="flex items-center justify-between gap-2 min-w-0 overflow-hidden">
+			<div className="flex items-center gap-2 min-w-0 overflow-hidden">
+				<div className="flex gap-1 shrink-0">
+					{teamInfo ? (
+						<TeamIcon logo={teamInfo.logo} name={teamInfo.name} />
+					) : (
+						players.map((player) => (
+							<AvatarWithFallback key={player.id} src={player.image} name={player.name} size="sm" />
+						))
+					)}
+				</div>
+				<span
+					className={cn(
+						"text-sm truncate",
+						isWinner && "font-semibold text-foreground",
+						isMuted && "text-muted-foreground",
+						!isWinner && !isMuted && "text-foreground"
+					)}
+				>
+					{getSideLabel(players)}
+				</span>
+			</div>
+			<span
+				data-testid={dataTestId}
+				className={cn(
+					"text-base tabular-nums shrink-0",
+					isWinner && "font-bold text-foreground",
+					isMuted && "text-muted-foreground font-medium",
+					!isWinner && !isMuted && "font-medium text-foreground"
+				)}
+			>
+				{score}
+			</span>
+		</div>
+	);
+}
+
+interface MatchScoreDisplayProps {
+	matchId: string;
+	homeScore: number;
+	awayScore: number;
+	createdAt: Date;
+	homePlayers: MatchDisplayPlayer[];
+	awayPlayers: MatchDisplayPlayer[];
+	compact?: boolean;
+}
+
+export function MatchScoreDisplay({
+	matchId,
+	homeScore,
+	awayScore,
+	createdAt,
+	homePlayers,
+	awayPlayers,
+	compact,
+}: MatchScoreDisplayProps) {
+	const homeWins = homeScore > awayScore;
+	const awayWins = awayScore > homeScore;
+	const timestamp = formatTimestamp(createdAt);
+
+	if (compact) {
+		return (
+			<div className="flex flex-col min-w-0" data-testid={`match-row-${matchId}`}>
+				<div className="flex flex-col gap-2 min-w-0">
+					<ScoreLine
+						players={homePlayers}
+						score={homeScore}
+						isWinner={homeWins}
+						isMuted={awayWins}
+					/>
+					<ScoreLine
+						players={awayPlayers}
+						score={awayScore}
+						isWinner={awayWins}
+						isMuted={homeWins}
+					/>
+				</div>
+				<div
+					className="text-xs text-muted-foreground text-right mt-3 pt-3 border-t border-border"
+					data-testid={`match-date-${matchId}`}
+				>
+					{timestamp.primary}
+					{timestamp.secondary && ` · ${timestamp.secondary}`}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex items-center min-w-0 overflow-hidden" data-testid={`match-row-${matchId}`}>
+			<div className="flex flex-col items-start shrink-0 w-16 md:w-20 mr-3 md:mr-4">
+				<span className="text-xs text-muted-foreground" data-testid={`match-date-${matchId}`}>
+					{timestamp.primary}
+				</span>
+				{timestamp.secondary && (
+					<span className="hidden md:block text-[11px] text-muted-foreground/60">
+						{timestamp.secondary}
+					</span>
+				)}
+			</div>
+
+			<div className="flex flex-col gap-2 min-w-0 flex-1">
+				<ScoreLine
+					players={homePlayers}
+					score={homeScore}
+					isWinner={homeWins}
+					isMuted={awayWins}
+					data-testid={`match-score-${matchId}-home`}
+				/>
+				<ScoreLine
+					players={awayPlayers}
+					score={awayScore}
+					isWinner={awayWins}
+					isMuted={homeWins}
+					data-testid={`match-score-${matchId}-away`}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/season/latest-matches.tsx
+++ b/apps/web/src/components/season/latest-matches.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { trpcClient } from "@/lib/trpc";
 import { OverviewCard } from "./overview-card";
-import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { MatchRow } from "@/components/match/match-row";
 import { Button } from "@/components/ui/button";
 import { Link, useParams } from "@tanstack/react-router";
@@ -104,16 +103,12 @@ function MatchTable({
 	seasonId: string;
 }) {
 	return (
-		<Table data-testid="latest-matches-table">
-			<TableBody className="text-sm">
-				{matches.map((match) => (
-					<TableRow key={match.id} data-testid={`latest-match-row-${match.id}`}>
-						<TableCell colSpan={3} className="p-0">
-							<MatchRow match={match} seasonSlug={seasonSlug} seasonId={seasonId} />
-						</TableCell>
-					</TableRow>
-				))}
-			</TableBody>
-		</Table>
+		<div className="divide-y divide-border overflow-hidden" data-testid="latest-matches-table">
+			{matches.map((match) => (
+				<div key={match.id} className="py-3 px-2" data-testid={`latest-match-row-${match.id}`}>
+					<MatchRow match={match} seasonSlug={seasonSlug} seasonId={seasonId} />
+				</div>
+			))}
+		</div>
 	);
 }

--- a/apps/web/src/components/sidebar/app-sidebar.tsx
+++ b/apps/web/src/components/sidebar/app-sidebar.tsx
@@ -47,9 +47,13 @@ const getAssetUrl = (key: string | null | undefined): string | null => {
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const { data: session } = authClient.useSession();
 	const { data: organizations } = authClient.useListOrganizations();
+	const { data: activeMember } = authClient.useActiveMember();
 	const matchRoute = useMatchRoute();
 	const { isMobile, setOpenMobile } = useSidebar();
 	const user = session?.user;
+
+	const userRole = activeMember?.role;
+	const canManageMembers = userRole === "owner" || userRole === "editor";
 
 	// Helper to close sidebar on mobile when navigating
 	const handleNavClick = () => {
@@ -207,30 +211,34 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 									</Link>
 								</SidebarMenuButton>
 							</SidebarMenuItem>
-							<SidebarMenuItem>
-								<SidebarMenuButton asChild isActive={!!isMembersRoute}>
-									<Link
-										to="/leagues/$slug/members"
-										params={{ slug: leagueSlug }}
-										onClick={handleNavClick}
-									>
-										<HugeiconsIcon icon={UserMultipleIcon} className="size-4" />
-										<span>Members</span>
-									</Link>
-								</SidebarMenuButton>
-							</SidebarMenuItem>
-							<SidebarMenuItem>
-								<SidebarMenuButton asChild isActive={!!isInvitationsRoute}>
-									<Link
-										to="/leagues/$slug/invitations"
-										params={{ slug: leagueSlug }}
-										onClick={handleNavClick}
-									>
-										<HugeiconsIcon icon={Mail01Icon} className="size-4" />
-										<span>Invitations</span>
-									</Link>
-								</SidebarMenuButton>
-							</SidebarMenuItem>
+							{canManageMembers && (
+								<>
+									<SidebarMenuItem>
+										<SidebarMenuButton asChild isActive={!!isMembersRoute}>
+											<Link
+												to="/leagues/$slug/members"
+												params={{ slug: leagueSlug }}
+												onClick={handleNavClick}
+											>
+												<HugeiconsIcon icon={UserMultipleIcon} className="size-4" />
+												<span>Members</span>
+											</Link>
+										</SidebarMenuButton>
+									</SidebarMenuItem>
+									<SidebarMenuItem>
+										<SidebarMenuButton asChild isActive={!!isInvitationsRoute}>
+											<Link
+												to="/leagues/$slug/invitations"
+												params={{ slug: leagueSlug }}
+												onClick={handleNavClick}
+											>
+												<HugeiconsIcon icon={Mail01Icon} className="size-4" />
+												<span>Invitations</span>
+											</Link>
+										</SidebarMenuButton>
+									</SidebarMenuItem>
+								</>
+							)}
 						</SidebarMenu>
 					</SidebarGroup>
 				)}

--- a/apps/web/src/routes/_auth/route.tsx
+++ b/apps/web/src/routes/_auth/route.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import { fetchSessionForRoute } from "@/hooks/useSession";
 

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
@@ -39,7 +39,7 @@ function SeasonDashboardPage() {
 	const { data: session } = useSession();
 	const { data: activeMember } = authClient.useActiveMember();
 	const role = activeMember?.role;
-	const canCreateMatches = role === "owner" || role === "editor";
+	const canCreateMatches = role === "owner" || role === "editor" || role === "member";
 
 	const { data: season, error } = useQuery({
 		queryKey: ["season", seasonSlug],
@@ -123,6 +123,13 @@ function SeasonDashboardPage() {
 									<Fixtures slug={slug} seasonSlug={seasonSlug} />
 								</OverviewCard>
 							)}
+							{seasonId && (
+								<LatestMatches
+									seasonId={seasonId}
+									seasonSlug={seasonSlug}
+									canDelete={canCreateMatches && !isSeasonLocked}
+								/>
+							)}
 						</div>
 						<div className="flex flex-col gap-4">
 							{seasonId && <TeamStandingCard seasonId={seasonId} seasonSlug={seasonSlug} />}
@@ -137,16 +144,14 @@ function SeasonDashboardPage() {
 								<Fixtures slug={slug} seasonSlug={seasonSlug} />
 							</OverviewCard>
 						)}
+						{seasonId && (
+							<LatestMatches
+								seasonId={seasonId}
+								seasonSlug={seasonSlug}
+								canDelete={canCreateMatches && !isSeasonLocked}
+							/>
+						)}
 					</div>
-				)}
-
-				{/* Latest Matches below standings for both layouts */}
-				{seasonId && (
-					<LatestMatches
-						seasonId={seasonId}
-						seasonSlug={seasonSlug}
-						canDelete={canCreateMatches && !isSeasonLocked}
-					/>
 				)}
 			</div>
 			{isEloSeason && seasonId && (

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
@@ -34,7 +34,7 @@ function MatchesPage() {
 
 	const { data: activeMember } = authClient.useActiveMember();
 	const role = activeMember?.role;
-	const canCreateMatches = role === "owner" || role === "editor";
+	const canCreateMatches = role === "owner" || role === "editor" || role === "member";
 	const canDeleteMatches = role === "owner" || role === "editor";
 
 	const { data: season } = useQuery({
@@ -181,7 +181,7 @@ function MatchesPage() {
 							</div>
 							<div
 								ref={parentRef}
-								className="h-[calc(100vh-400px)] overflow-auto border divide-y divide-border"
+								className="h-[calc(100vh-400px)] overflow-auto rounded-lg bg-card mx-auto max-w-2xl"
 							>
 								<div
 									style={{
@@ -208,7 +208,7 @@ function MatchesPage() {
 														width: "100%",
 														transform: `translateY(${virtualItem.start}px)`,
 													}}
-													className="hover:bg-muted/50 transition-colors border-b border-border last:border-b-0"
+													className="hover:bg-muted/50 transition-colors border-b border-border/50 last:border-b-0 py-3 px-2 overflow-hidden"
 												>
 													<MatchRow
 														match={match}

--- a/apps/web/src/routes/_authenticated/_sidebar/route.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/route.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 import { AppSidebar } from "@/components/sidebar/app-sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { fetchSessionForRoute } from "@/hooks/useSession";

--- a/apps/web/src/routes/_authenticated/leagues/index.tsx
+++ b/apps/web/src/routes/_authenticated/leagues/index.tsx
@@ -33,6 +33,7 @@ function LeaguesListPage() {
 		<div className="flex min-h-screen flex-col">
 			<Header
 				includeLogoutButton
+				includeSidebarTrigger={false}
 				rightContent={
 					<GlowButton
 						icon={Add01Icon}

--- a/apps/web/src/routes/accept-invitation.$invitationId.tsx
+++ b/apps/web/src/routes/accept-invitation.$invitationId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
 import { toast } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { AvatarWithFallback } from "@/components/ui/avatar-with-fallback";
@@ -162,6 +163,7 @@ function AcceptInvitationPage() {
 
 	return (
 		<div className="flex min-h-screen items-center justify-center p-4">
+			<Toaster position="bottom-center" />
 			<Card className="w-full max-w-md">
 				<CardHeader className="text-center">
 					<div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 mb-4">

--- a/apps/worker/src/trpc/router/match-router.ts
+++ b/apps/worker/src/trpc/router/match-router.ts
@@ -8,7 +8,7 @@ import * as seasonPlayerRepository from "../../repositories/season-player-reposi
 import { broadcastSeasonEvent } from "../../routes/sse-router";
 import {
 	seasonProcedure,
-	leagueEditorProcedure,
+	leagueMemberProcedure,
 	type LeagueContext,
 	type SeasonContext,
 } from "../trpc";
@@ -17,7 +17,7 @@ import {
 const matchIdSchema = createOptionalIdSchema("match");
 
 export const matchRouter = {
-	create: leagueEditorProcedure
+	create: leagueMemberProcedure
 		.input(
 			z.object({
 				id: matchIdSchema,

--- a/apps/worker/src/trpc/trpc.ts
+++ b/apps/worker/src/trpc/trpc.ts
@@ -78,6 +78,7 @@ const enforceActiveOrg = t.middleware(({ ctx, next }) => {
 
 // Editor roles constant
 export const editorRoles = ["owner", "editor"];
+export const memberRoles = ["owner", "editor", "member"];
 
 // League access middleware - verifies user is member of organization
 const leagueAccessMiddleware = t.middleware(async ({ ctx, next }) => {
@@ -167,6 +168,15 @@ const editorCheckMiddleware = t.middleware(({ ctx, next }) => {
 	return next({ ctx });
 });
 
+// Member check middleware - allows members to create content
+const memberCheckMiddleware = t.middleware(({ ctx, next }) => {
+	const typedCtx = ctx as unknown as LeagueContext;
+	if (!memberRoles.includes(typedCtx.role)) {
+		throw new TRPCError({ code: "FORBIDDEN", message: "Insufficient permissions" });
+	}
+	return next({ ctx });
+});
+
 export const createTRPCRouter = t.router;
 export const publicProcedure = t.procedure;
 export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);
@@ -186,6 +196,11 @@ export const leagueEditorProcedure = t.procedure
 	.use(enforceUserIsAuthed)
 	.use(leagueAccessMiddleware)
 	.use(editorCheckMiddleware);
+
+export const leagueMemberProcedure = t.procedure
+	.use(enforceUserIsAuthed)
+	.use(leagueAccessMiddleware)
+	.use(memberCheckMiddleware);
 
 // Export types for use in routers
 export type { LeagueContext, SeasonContext };


### PR DESCRIPTION
## Summary

- Hide Members/Invitations links from non-editors in sidebar
- Fix useSidebar error on /leagues route during mobile invite acceptance
- Fix toast backgrounds in dark mode by using custom Toaster wrapper
- Allow members to create matches with new leagueMemberProcedure
- Improve match score display with winner emphasis and inline team-score pairing
- Fix create match dialog jumping by pinning to top
- Fix horizontal scroll on mobile match lists with proper overflow handling
- Consolidate duplicated match display logic into shared MatchScoreDisplay component