### PR TITLE
fix(auth): await session refetch before navigation after sign-in

### DIFF
--- a/apps/web/src/components/auth/sign-in-form.tsx
+++ b/apps/web/src/components/auth/sign-in-form.tsx
@@ -11,6 +11,7 @@ import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
+import { useSessionInvalidate } from "@/hooks/useSession";
 
 const signInSchema = z.object({
 	email: z.string().email("Please enter a valid email address"),
@@ -28,6 +29,7 @@ const isEmailPasswordEnabled = !import.meta.env.VITE_DISABLE_EMAIL_PASSWORD;
 
 export function SignInForm({ callbackURL, error }: SignInFormProps) {
 	const navigate = useNavigate();
+	const invalidateSession = useSessionInvalidate();
 	const [isGitHubLoading, setIsGitHubLoading] = useState(false);
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 	const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
@@ -93,6 +95,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 			}
 
 			if (data) {
+				await invalidateSession();
 				navigate({ to: callbackURL || "/" });
 			} else {
 				setApiError("Failed to sign in. Please try again.");
@@ -184,6 +187,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 			}
 
 			if (data) {
+				await invalidateSession();
 				navigate({ to: callbackURL || "/" });
 			} else {
 				setApiError("Failed to sign in with passkey. Please try again.");

--- a/apps/web/src/components/auth/sign-up-form.tsx
+++ b/apps/web/src/components/auth/sign-up-form.tsx
@@ -4,7 +4,6 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useQueryClient } from "@tanstack/react-query";
 import * as z from "zod";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -12,7 +11,7 @@ import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
-import { SESSION_QUERY_KEY } from "@/hooks/useSession";
+import { useSessionInvalidate } from "@/hooks/useSession";
 
 const signUpSchema = z.object({
 	name: z.string().min(1, "Name is required"),
@@ -31,7 +30,7 @@ const isEmailPasswordEnabled = !import.meta.env.VITE_DISABLE_EMAIL_PASSWORD;
 
 export function SignUpForm({ callbackURL, error }: SignUpFormProps) {
 	const navigate = useNavigate();
-	const queryClient = useQueryClient();
+	const invalidateSession = useSessionInvalidate();
 	const [isGitHubLoading, setIsGitHubLoading] = useState(false);
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 	const [apiError, setApiError] = useState<string>("");
@@ -90,8 +89,7 @@ export function SignUpForm({ callbackURL, error }: SignUpFormProps) {
 					return;
 				}
 
-				// Invalidate session cache to ensure fresh data
-				void queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
+				await invalidateSession();
 
 				// Successfully signed in, redirect to callback URL
 				void navigate({ to: callbackURL || "/" });

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -22,13 +22,14 @@ export function useSession() {
 }
 
 /**
- * Hook to get session invalidation function for use in mutations
+ * Hook to get session refetch function for use after auth state changes
+ * Returns a promise that resolves when the session is refetched
  */
 export function useSessionInvalidate() {
 	const queryClient = useQueryClient();
 
 	return () => {
-		queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
+		return queryClient.refetchQueries({ queryKey: SESSION_QUERY_KEY });
 	};
 }
 


### PR DESCRIPTION
## Summary

Fixes a race condition where users would see the Landing page briefly after signing in, instead of being redirected to their dashboard.

## Problem

After successful authentication (email/password or passkey), the flow was:

1. `authClient.signIn.email()` succeeds
2. `invalidateSession()` marks the session query as stale
3. `navigate({ to: "/" })` triggers immediately
4. Route's `beforeLoad` calls `fetchSessionForRoute(queryClient)`
5. Query returns stale/null cached data because refetch hasn't completed
6. Landing page renders instead of authenticated redirect

The `useSession()` hook worked correctly because React Query refetches invalidated queries asynchronously when the component re-renders.

## Solution

- Changed `useSessionInvalidate()` to use `refetchQueries()` instead of `invalidateQueries()`
- `refetchQueries()` returns a Promise that resolves when the refetch completes
- Updated sign-in and sign-up forms to `await invalidateSession()` before navigating
- This ensures fresh session data is in the React Query cache before the route's `beforeLoad` runs

## Changes

| File | Change |
|------|--------|
| `apps/web/src/hooks/useSession.ts` | `useSessionInvalidate` now uses `refetchQueries()` and returns a Promise |
| `apps/web/src/components/auth/sign-in-form.tsx` | Added `await` before `invalidateSession()` for email and passkey sign-in |
| `apps/web/src/components/auth/sign-up-form.tsx` | Added `await` before `invalidateSession()`, refactored to use hook consistently |

## Testing

Manually verified with browser automation:
1. Navigated to `/auth/sign-in`
2. Entered credentials and clicked Sign In
3. Confirmed redirect to `/leagues/scorebrawl/seasons/season-01` (authenticated dashboard)
4. Previously this would show the Landing page briefly or require a page refresh