### PR TITLE
fix: PostgreSQL to D1 migration script table naming

### DIFF
--- a/apps/web/src/components/auth/sign-in-form.tsx
+++ b/apps/web/src/components/auth/sign-in-form.tsx
@@ -168,7 +168,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 					errorMessage.toLowerCase().includes("abort")
 				) {
 					displayMessage =
-						"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in with email/password first, then add a passkey in your profile settings.";
+						"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in using another method, then add a passkey in your profile settings.";
 				} else if (errorMessage.toLowerCase().includes("not allowed")) {
 					displayMessage =
 						"Passkey sign-in was not allowed. Please try again or use another sign-in method.";
@@ -178,7 +178,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 					errorMessage.toLowerCase().includes("no credential")
 				) {
 					displayMessage =
-						"No passkey found for this account. Please sign in with email/password first, then add a passkey in your profile settings.";
+						"No passkey found for this account. Please sign in using another method, then add a passkey in your profile settings.";
 				}
 
 				setApiError(displayMessage || "Failed to sign in with passkey. Please try again.");
@@ -203,7 +203,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 				(err instanceof DOMException && err.name === "AbortError")
 			) {
 				displayMessage =
-					"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in with email/password first, then add a passkey in your profile settings.";
+					"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in using another method, then add a passkey in your profile settings.";
 			} else if (
 				errorMessage.toLowerCase().includes("not allowed") ||
 				(err instanceof DOMException && err.name === "NotAllowedError")
@@ -217,7 +217,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 				(err instanceof DOMException && err.name === "NotFoundError")
 			) {
 				displayMessage =
-					"No passkey found for this account. Please sign in with email/password first, then add a passkey in your profile settings.";
+					"No passkey found for this account. Please sign in using another method, then add a passkey in your profile settings.";
 			}
 
 			setApiError(displayMessage || "Failed to sign in with passkey. Please try again.");

--- a/apps/web/src/components/match/remove-match-dialog.tsx
+++ b/apps/web/src/components/match/remove-match-dialog.tsx
@@ -70,6 +70,7 @@ export function RemoveMatchDialog({
 			// Invalidate match and standings collections
 			queryClient.invalidateQueries({ queryKey: ["matches", seasonId] });
 			queryClient.invalidateQueries({ queryKey: ["standings", seasonId] });
+			queryClient.invalidateQueries({ queryKey: ["team-standings", seasonId] });
 
 			// Invalidate tRPC queries
 			queryClient.invalidateQueries({

--- a/apps/web/src/lib/collections/match-collection.ts
+++ b/apps/web/src/lib/collections/match-collection.ts
@@ -94,6 +94,18 @@ function createMatchCollectionInternal(seasonId: string, seasonSlug: string) {
 }
 
 export function createMatchCollection(seasonId: string, seasonSlug: string) {
+	// Handle empty seasonId gracefully
+	if (!seasonId) {
+		// Return a dummy collection for initial render
+		const dummyId = "__DUMMY__";
+		const existing = matchCollections.get(dummyId);
+		if (existing) return existing;
+
+		const dummyCollection = createMatchCollectionInternal(dummyId, seasonSlug);
+		matchCollections.set(dummyId, dummyCollection);
+		return dummyCollection;
+	}
+
 	const existing = matchCollections.get(seasonId);
 	if (existing) return existing;
 
@@ -129,17 +141,9 @@ export function loadMoreMatches(seasonId: string, seasonSlug: string, currentCou
 }
 
 export function useMatches(seasonId: string, seasonSlug: string) {
-	// Skip if no valid seasonId
-	if (!seasonId) {
-		return {
-			matches: [],
-			collection: null as ReturnType<typeof createMatchCollection> | null,
-		};
-	}
-
+	// Create collection - seasonId is guaranteed to be defined
 	const collection = createMatchCollection(seasonId, seasonSlug);
 
-	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const { data: matches } = useLiveQuery(
 		(q) =>
 			q
@@ -158,7 +162,7 @@ export function useMatches(seasonId: string, seasonSlug: string) {
 	);
 
 	return {
-		matches: matches ?? [],
+		matches: (matches ?? []) as Match[],
 		collection,
 	};
 }

--- a/scripts/migrate-pg-to-d1.ts
+++ b/scripts/migrate-pg-to-d1.ts
@@ -97,11 +97,11 @@ async function main() {
 		// 8. player_achievement (from league_player_achievement)
 		await migratePlayerAchievement(pgClient, sqlite);
 
-		// 9. org_team (from league_team)
-		await migrateOrgTeam(pgClient, sqlite);
+		// 9. league_team (from league_team)
+		await migrateLeagueTeam(pgClient, sqlite);
 
-		// 10. org_team_player (from league_team_player)
-		await migrateOrgTeamPlayer(pgClient, sqlite);
+		// 10. league_team_player (from league_team_player)
+		await migrateLeagueTeamPlayer(pgClient, sqlite);
 
 		// 11. season
 		await migrateSeason(pgClient, sqlite);
@@ -310,30 +310,30 @@ async function migratePlayerAchievement(pgClient: pg.Client, sqlite: Database) {
 	}
 }
 
-async function migrateOrgTeam(pgClient: pg.Client, sqlite: Database) {
+async function migrateLeagueTeam(pgClient: pg.Client, sqlite: Database) {
 	const { rows } = await pgClient.query(
 		"SELECT id, name, league_id, created_at, updated_at FROM league_team"
 	);
-	logEntity("org_team", rows.length);
+	logEntity("league_team", rows.length);
 	if (dryRun) return;
 
 	const stmt = sqlite.prepare(
-		"INSERT INTO org_team (id, name, league_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?)"
+		"INSERT INTO league_team (id, name, league_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?)"
 	);
 	for (const r of rows) {
 		stmt.run(r.id, r.name, r.league_id, tsToSec(r.created_at), tsToSec(r.updated_at), null);
 	}
 }
 
-async function migrateOrgTeamPlayer(pgClient: pg.Client, sqlite: Database) {
+async function migrateLeagueTeamPlayer(pgClient: pg.Client, sqlite: Database) {
 	const { rows } = await pgClient.query(
 		"SELECT id, league_player_id, team_id, created_at, updated_at FROM league_team_player"
 	);
-	logEntity("org_team_player", rows.length);
+	logEntity("league_team_player", rows.length);
 	if (dryRun) return;
 
 	const stmt = sqlite.prepare(
-		"INSERT INTO org_team_player (id, player_id, org_team_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?)"
+		"INSERT INTO league_team_player (id, player_id, league_team_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?)"
 	);
 	for (const r of rows) {
 		stmt.run(
@@ -412,7 +412,7 @@ async function migrateSeasonTeam(pgClient: pg.Client, sqlite: Database) {
 	if (dryRun) return;
 
 	const stmt = sqlite.prepare(
-		"INSERT INTO season_team (id, season_id, org_team_id, score, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+		"INSERT INTO season_team (id, season_id, league_team_id, score, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
 	);
 	for (const r of rows) {
 		stmt.run(


### PR DESCRIPTION
## Summary

- Fixed incorrect table naming in migration script (org_team → league_team, org_team_player → league_team_player)
- Corrected season_team foreign key reference to use league_team_id
- Improved passkey error messages to be auth-method agnostic
- Enhanced match collection stability with empty seasonId handling
- Fixed infinite scroll implementation using native scroll listener

## Changes

### Migration Script
- Renamed `migrateOrgTeam` → `migrateLeagueTeam` with correct table name
- Renamed `migrateOrgTeamPlayer` → `migrateLeagueTeamPlayer` with correct table name
- Updated season_team insert to reference `league_team_id` column

### Frontend Improvements
- Updated passkey error messages to avoid referencing specific auth methods
- Added graceful handling for empty seasonId in match collection
- Invalidate team-standings cache on match removal
- Replaced virtualizer-based infinite scroll with native scroll listener
- Simplified matches page UI