### PR TITLE
feat: improve match UI with score styling, dialog URL params, and keep-open option

### DIFF
--- a/apps/web/src/components/match/match-score-display.tsx
+++ b/apps/web/src/components/match/match-score-display.tsx
@@ -116,17 +116,17 @@ function ScoreLine({
 					{getSideLabel(players)}
 				</span>
 			</div>
-			<span
+			<div
 				data-testid={dataTestId}
 				className={cn(
-					"text-base tabular-nums shrink-0",
+					"flex h-7 w-7 items-center justify-center rounded-md border text-sm tabular-nums shrink-0 bg-primary/10",
 					isWinner && "font-bold text-foreground",
 					isMuted && "text-muted-foreground font-medium",
 					!isWinner && !isMuted && "font-medium text-foreground"
 				)}
 			>
 				{score}
-			</span>
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/components/season/dashboard-cards.tsx
+++ b/apps/web/src/components/season/dashboard-cards.tsx
@@ -195,7 +195,15 @@ function getSideLabel(players: MatchPlayer[]): string {
 	return players.map((p) => p.name).join(", ");
 }
 
-function SideDisplay({ players }: { players: MatchPlayer[] }) {
+function SideDisplay({
+	players,
+	isWinner,
+	isMuted,
+}: {
+	players: MatchPlayer[];
+	isWinner?: boolean;
+	isMuted?: boolean;
+}) {
 	const teamInfo = getTeamInfo(players);
 
 	return (
@@ -209,7 +217,16 @@ function SideDisplay({ players }: { players: MatchPlayer[] }) {
 					))
 				)}
 			</div>
-			<span className="text-xs text-muted-foreground truncate">{getSideLabel(players)}</span>
+			<span
+				className={cn(
+					"text-xs truncate",
+					isWinner && "font-semibold text-foreground",
+					isMuted && "text-muted-foreground",
+					!isWinner && !isMuted && "text-muted-foreground"
+				)}
+			>
+				{getSideLabel(players)}
+			</span>
 		</div>
 	);
 }
@@ -222,6 +239,8 @@ function LatestMatchCard({ seasonSlug }: { seasonSlug: string }) {
 
 	const homePlayers = latestMatch?.players?.filter((p: MatchPlayer) => p.homeTeam) ?? [];
 	const awayPlayers = latestMatch?.players?.filter((p: MatchPlayer) => !p.homeTeam) ?? [];
+	const homeWins = (latestMatch?.homeScore ?? 0) > (latestMatch?.awayScore ?? 0);
+	const awayWins = (latestMatch?.awayScore ?? 0) > (latestMatch?.homeScore ?? 0);
 
 	return (
 		<DashboardCard
@@ -236,17 +255,31 @@ function LatestMatchCard({ seasonSlug }: { seasonSlug: string }) {
 				<div className="space-y-2 min-w-0">
 					<div className="flex items-center gap-3 min-w-0">
 						<div className="min-w-0 flex-1">
-							<SideDisplay players={homePlayers} />
+							<SideDisplay players={homePlayers} isWinner={homeWins} isMuted={awayWins} />
 						</div>
-						<div className="flex h-7 w-7 items-center justify-center rounded-md border text-sm font-medium shrink-0 bg-primary/10">
+						<div
+							className={cn(
+								"flex h-7 w-7 items-center justify-center rounded-md border text-sm shrink-0 bg-primary/10",
+								homeWins && "font-bold text-foreground",
+								awayWins && "text-muted-foreground font-medium",
+								!homeWins && !awayWins && "font-medium text-foreground"
+							)}
+						>
 							{latestMatch.homeScore}
 						</div>
 					</div>
 					<div className="flex items-center gap-3 min-w-0">
 						<div className="min-w-0 flex-1">
-							<SideDisplay players={awayPlayers} />
+							<SideDisplay players={awayPlayers} isWinner={awayWins} isMuted={homeWins} />
 						</div>
-						<div className="flex h-7 w-7 items-center justify-center rounded-md border text-sm font-medium shrink-0 bg-primary/10">
+						<div
+							className={cn(
+								"flex h-7 w-7 items-center justify-center rounded-md border text-sm shrink-0 bg-primary/10",
+								awayWins && "font-bold text-foreground",
+								homeWins && "text-muted-foreground font-medium",
+								!homeWins && !awayWins && "font-medium text-foreground"
+							)}
+						>
 							{latestMatch.awayScore}
 						</div>
 					</div>

--- a/apps/web/src/components/ui/form-dots.tsx
+++ b/apps/web/src/components/ui/form-dots.tsx
@@ -15,7 +15,7 @@ export function FormDots({ form }: FormDotsProps) {
 
 	return (
 		<div className="flex gap-1 justify-center">
-			{form.map((result, index) => {
+			{[...form].reverse().map((result, index) => {
 				const baseClasses = "w-2 h-2 rounded-full";
 				const colorClasses = {
 					W: "bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.6)]",

--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Header } from "@/components/layout/header";
 import { GlowButton, glowColors } from "@/components/ui/glow-button";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -15,10 +15,16 @@ import { Fixtures } from "@/components/season/fixtures";
 import { OverviewCard } from "@/components/season/overview-card";
 import { CreateMatchDialog } from "@/components/match/create-match-drawer";
 import { useSeasonSSE } from "@/hooks/use-season-sse";
+import { z } from "zod";
+
+const seasonDashboardSearchSchema = z.object({
+	addMatch: z.boolean().optional(),
+});
 
 export const Route = createFileRoute("/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/")(
 	{
 		component: SeasonDashboardPage,
+		validateSearch: seasonDashboardSearchSchema,
 		loader: async ({ params }) => {
 			return { slug: params.slug, seasonSlug: params.seasonSlug };
 		},
@@ -82,7 +88,14 @@ function SeasonDashboardPage() {
 	const isEloSeason = season?.scoreType === "elo";
 	const isSeasonLocked = season?.closed || season?.archived;
 
-	const [isCreateMatchOpen, setIsCreateMatchOpen] = useState(false);
+	const { addMatch } = Route.useSearch();
+	const isCreateMatchOpen = addMatch === true;
+	const setIsCreateMatchOpen = (open: boolean) => {
+		navigate({
+			to: ".",
+			search: open ? { addMatch: true } : {},
+		});
+	};
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

This PR improves the match creation and display experience with several UI enhancements:

- **Consistent score box styling** across match list and dashboard
- **URL-based dialog control** for direct linking to create match
- **Keep-open option** for rapid match logging
- **Form dots order fix** for correct chronological display

## Changes

### Score Display Styling
- Added styled score boxes (`rounded-md border bg-primary/10`) to match list rows in `MatchScoreDisplay`
- Applied the same styling to the Latest Match dashboard card
- Implemented winner/loser visual hierarchy: bold text for winner, muted for loser (both score and player name)

### Create Match Dialog URL Params
- Added `?addMatch=true` query parameter support to both:
  - Season dashboard (`/leagues/$slug/seasons/$seasonSlug?addMatch=true`)
  - Matches page (`/leagues/$slug/seasons/$seasonSlug/matches?addMatch=true`)
- Enables direct linking to the create match dialog

### Keep Open After Creating
- Added "Keep open after creating" checkbox to the create match dialog footer
- When checked, dialog resets (scores to 0, player selections cleared) instead of closing after successful match creation
- Styled with blue glow effect matching the GlowButton component:
  - `bg-blue-500/10` background
  - `border-blue-500/20` border
  - `text-blue-600` text color
  - Subtle glow shadow effect
- Improves workflow for logging multiple matches quickly

### Form Dots Fix
- Reversed the form dots display order to show most recent results first

## Files Changed

- `apps/web/src/components/match/create-match-drawer.tsx` - Keep-open checkbox and reset logic
- `apps/web/src/components/match/match-score-display.tsx` - Score box styling
- `apps/web/src/components/season/dashboard-cards.tsx` - Latest match card winner/loser styling
- `apps/web/src/components/ui/form-dots.tsx` - Reverse display order
- `apps/web/src/routes/.../index.tsx` - Search param support for dialog
- `apps/web/src/routes/.../matches.tsx` - Search param support for dialog

## Testing

- All existing tests pass (`bun run test`)
- Linting passes (`bun oxc`)
- Type checking passes (`bun typecheck`)