### PR TITLE
Disable passkey authentication due to Workers CPU limits

### DIFF
--- a/apps/web/src/components/auth/sign-in-form.tsx
+++ b/apps/web/src/components/auth/sign-in-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { GithubIcon, GoogleIcon, Key01Icon } from "@hugeicons/core-free-icons";
+import { GithubIcon, GoogleIcon /*, Key01Icon */ } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
@@ -32,9 +32,9 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 	const invalidateSession = useSessionInvalidate();
 	const [isGitHubLoading, setIsGitHubLoading] = useState(false);
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
-	const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
+	// const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
 	const [apiError, setApiError] = useState<string>("");
-	const [supportsPasskey, setSupportsPasskey] = useState(false);
+	// const [supportsPasskey, setSupportsPasskey] = useState(false);
 
 	// Set error from URL query param
 	useEffect(() => {
@@ -47,26 +47,28 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 		}
 	}, [error]);
 
-	// Preload passkeys for conditional UI
-	useEffect(() => {
-		if (
-			typeof PublicKeyCredential === "undefined" ||
-			!PublicKeyCredential.isConditionalMediationAvailable
-		) {
-			return;
-		}
-
-		void (async () => {
-			const isAvailable = await PublicKeyCredential.isConditionalMediationAvailable();
-			setSupportsPasskey(isAvailable);
-			if (isAvailable) {
-				// Silently handle errors for conditional UI (user might not have passkeys)
-				void authClient.signIn.passkey({ autoFill: true }).catch(() => {
-					// Ignore errors for conditional UI preload
-				});
-			}
-		})();
-	}, []);
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// // Preload passkeys for conditional UI
+	// useEffect(() => {
+	// 	if (
+	// 		typeof PublicKeyCredential === "undefined" ||
+	// 		!PublicKeyCredential.isConditionalMediationAvailable
+	// 	) {
+	// 		return;
+	// 	}
+	//
+	// 	void (async () => {
+	// 		const isAvailable = await PublicKeyCredential.isConditionalMediationAvailable();
+	// 		setSupportsPasskey(isAvailable);
+	// 		if (isAvailable) {
+	// 			// Silently handle errors for conditional UI (user might not have passkeys)
+	// 			void authClient.signIn.passkey({ autoFill: true }).catch(() => {
+	// 				// Ignore errors for conditional UI preload
+	// 			});
+	// 		}
+	// 	})();
+	// }, []);
 
 	const {
 		register,
@@ -151,79 +153,81 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 		}
 	};
 
-	const handlePasskeySignIn = async () => {
-		setIsPasskeyLoading(true);
-		setApiError("");
-		try {
-			const { data, error } = await authClient.signIn.passkey({
-				autoFill: false,
-			});
-
-			if (error) {
-				const errorMessage = error.message || "";
-				// Provide user-friendly messages for common errors
-				let displayMessage = errorMessage;
-				if (
-					errorMessage.toLowerCase().includes("cancelled") ||
-					errorMessage.toLowerCase().includes("abort")
-				) {
-					displayMessage =
-						"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in using another method, then add a passkey in your profile settings.";
-				} else if (errorMessage.toLowerCase().includes("not allowed")) {
-					displayMessage =
-						"Passkey sign-in was not allowed. Please try again or use another sign-in method.";
-				} else if (
-					errorMessage.toLowerCase().includes("not found") ||
-					errorMessage.toLowerCase().includes("no passkey") ||
-					errorMessage.toLowerCase().includes("no credential")
-				) {
-					displayMessage =
-						"No passkey found for this account. Please sign in using another method, then add a passkey in your profile settings.";
-				}
-
-				setApiError(displayMessage || "Failed to sign in with passkey. Please try again.");
-				setIsPasskeyLoading(false);
-				return;
-			}
-
-			if (data) {
-				await invalidateSession();
-				navigate({ to: callbackURL || "/" });
-			} else {
-				setApiError("Failed to sign in with passkey. Please try again.");
-				setIsPasskeyLoading(false);
-			}
-		} catch (err) {
-			const errorMessage = err instanceof Error ? err.message : String(err);
-			// Provide user-friendly messages for common errors
-			let displayMessage = errorMessage;
-			if (
-				errorMessage.toLowerCase().includes("cancelled") ||
-				errorMessage.toLowerCase().includes("abort") ||
-				(err instanceof DOMException && err.name === "AbortError")
-			) {
-				displayMessage =
-					"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in using another method, then add a passkey in your profile settings.";
-			} else if (
-				errorMessage.toLowerCase().includes("not allowed") ||
-				(err instanceof DOMException && err.name === "NotAllowedError")
-			) {
-				displayMessage =
-					"Passkey sign-in was not allowed. Please try again or use another sign-in method.";
-			} else if (
-				errorMessage.toLowerCase().includes("not found") ||
-				errorMessage.toLowerCase().includes("no passkey") ||
-				errorMessage.toLowerCase().includes("no credential") ||
-				(err instanceof DOMException && err.name === "NotFoundError")
-			) {
-				displayMessage =
-					"No passkey found for this account. Please sign in using another method, then add a passkey in your profile settings.";
-			}
-
-			setApiError(displayMessage || "Failed to sign in with passkey. Please try again.");
-			setIsPasskeyLoading(false);
-		}
-	};
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// const handlePasskeySignIn = async () => {
+	// 	setIsPasskeyLoading(true);
+	// 	setApiError("");
+	// 	try {
+	// 		const { data, error } = await authClient.signIn.passkey({
+	// 			autoFill: false,
+	// 		});
+	//
+	// 		if (error) {
+	// 			const errorMessage = error.message || "";
+	// 			// Provide user-friendly messages for common errors
+	// 			let displayMessage = errorMessage;
+	// 			if (
+	// 				errorMessage.toLowerCase().includes("cancelled") ||
+	// 				errorMessage.toLowerCase().includes("abort")
+	// 			) {
+	// 				displayMessage =
+	// 					"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in using another method, then add a passkey in your profile settings.";
+	// 			} else if (errorMessage.toLowerCase().includes("not allowed")) {
+	// 				displayMessage =
+	// 					"Passkey sign-in was not allowed. Please try again or use another sign-in method.";
+	// 			} else if (
+	// 				errorMessage.toLowerCase().includes("not found") ||
+	// 				errorMessage.toLowerCase().includes("no passkey") ||
+	// 				errorMessage.toLowerCase().includes("no credential")
+	// 			) {
+	// 				displayMessage =
+	// 					"No passkey found for this account. Please sign in using another method, then add a passkey in your profile settings.";
+	// 			}
+	//
+	// 			setApiError(displayMessage || "Failed to sign in with passkey. Please try again.");
+	// 			setIsPasskeyLoading(false);
+	// 			return;
+	// 		}
+	//
+	// 		if (data) {
+	// 			await invalidateSession();
+	// 			navigate({ to: callbackURL || "/" });
+	// 		} else {
+	// 			setApiError("Failed to sign in with passkey. Please try again.");
+	// 			setIsPasskeyLoading(false);
+	// 		}
+	// 	} catch (err) {
+	// 		const errorMessage = err instanceof Error ? err.message : String(err);
+	// 		// Provide user-friendly messages for common errors
+	// 		let displayMessage = errorMessage;
+	// 		if (
+	// 			errorMessage.toLowerCase().includes("cancelled") ||
+	// 			errorMessage.toLowerCase().includes("abort") ||
+	// 			(err instanceof DOMException && err.name === "AbortError")
+	// 		) {
+	// 			displayMessage =
+	// 				"Passkey sign-in was cancelled. This can happen if you don't have a passkey registered for this account, or if you cancelled the browser prompt. Please sign in using another method, then add a passkey in your profile settings.";
+	// 		} else if (
+	// 			errorMessage.toLowerCase().includes("not allowed") ||
+	// 			(err instanceof DOMException && err.name === "NotAllowedError")
+	// 		) {
+	// 			displayMessage =
+	// 				"Passkey sign-in was not allowed. Please try again or use another sign-in method.";
+	// 		} else if (
+	// 			errorMessage.toLowerCase().includes("not found") ||
+	// 			errorMessage.toLowerCase().includes("no passkey") ||
+	// 			errorMessage.toLowerCase().includes("no credential") ||
+	// 			(err instanceof DOMException && err.name === "NotFoundError")
+	// 		) {
+	// 			displayMessage =
+	// 				"No passkey found for this account. Please sign in using another method, then add a passkey in your profile settings.";
+	// 		}
+	//
+	// 		setApiError(displayMessage || "Failed to sign in with passkey. Please try again.");
+	// 		setIsPasskeyLoading(false);
+	// 	}
+	// };
 
 	return (
 		<Card className="w-full max-w-md border-border">
@@ -301,9 +305,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 					</form>
 				)}
 
-				{(import.meta.env.VITE_GITHUB_CLIENT_ID ||
-					import.meta.env.VITE_GOOGLE_CLIENT_ID ||
-					supportsPasskey) && (
+				{(import.meta.env.VITE_GITHUB_CLIENT_ID || import.meta.env.VITE_GOOGLE_CLIENT_ID) && (
 					<>
 						{isEmailPasswordEnabled && (
 							<div className="relative my-4">
@@ -321,7 +323,9 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 						)}
 
 						<div className="flex flex-col gap-2">
-							{supportsPasskey && (
+							{/* Passkey support disabled due to Cloudflare Workers CPU limits */}
+							{/* TODO: Re-enable when upgrading to Workers Paid plan */}
+							{/* {supportsPasskey && (
 								<Button
 									variant="outline"
 									className="w-full"
@@ -332,7 +336,7 @@ export function SignInForm({ callbackURL, error }: SignInFormProps) {
 									<HugeiconsIcon icon={Key01Icon} className="mr-2 h-4 w-4" />
 									{isPasskeyLoading ? "Signing in..." : "Sign in with Passkey"}
 								</Button>
-							)}
+							)} */}
 							{import.meta.env.VITE_GITHUB_CLIENT_ID && (
 								<Button
 									variant="outline"

--- a/apps/web/src/routes/_authenticated/_sidebar/profile.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/profile.tsx
@@ -2,9 +2,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
-	Delete01Icon,
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// Delete01Icon,
 	Edit01Icon,
-	Key01Icon,
+	// Key01Icon,
 	Logout01Icon,
 	UserIcon,
 	Award01Icon,
@@ -14,17 +16,19 @@ import {
 } from "@hugeicons/core-free-icons";
 import { useState } from "react";
 import { toast } from "sonner";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-	AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+// Passkey support disabled due to Cloudflare Workers CPU limits
+// TODO: Re-enable when upgrading to Workers Paid plan
+// import {
+// 	AlertDialog,
+// 	AlertDialogAction,
+// 	AlertDialogCancel,
+// 	AlertDialogContent,
+// 	AlertDialogDescription,
+// 	AlertDialogFooter,
+// 	AlertDialogHeader,
+// 	AlertDialogTitle,
+// 	AlertDialogTrigger,
+// } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -33,7 +37,9 @@ import { RowCard } from "@/components/ui/row-card";
 import { Header } from "@/components/layout/header";
 import { authClient } from "@/lib/auth-client";
 import { EditProfileDialog } from "@/components/profile/edit-profile-dialog";
-import { EditPasskeyDialog } from "@/components/profile/edit-passkey-dialog";
+// Passkey support disabled due to Cloudflare Workers CPU limits
+// TODO: Re-enable when upgrading to Workers Paid plan
+// import { EditPasskeyDialog } from "@/components/profile/edit-passkey-dialog";
 import { useSession, fetchSessionForRoute } from "@/hooks/useSession";
 import { useSignOut } from "@/hooks/useSignOut";
 import { useTRPC } from "@/lib/trpc";
@@ -63,7 +69,9 @@ function ProfilePage() {
 	const user = currentSession?.user;
 
 	const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
-	const [editingPasskey, setEditingPasskey] = useState<{ id: string; name: string } | null>(null);
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// const [editingPasskey, setEditingPasskey] = useState<{ id: string; name: string } | null>(null);
 	const [isRevokeOtherDialogOpen, setIsRevokeOtherDialogOpen] = useState(false);
 	const [isRevokeAllDialogOpen, setIsRevokeAllDialogOpen] = useState(false);
 	const queryClient = useQueryClient();
@@ -75,17 +83,19 @@ function ProfilePage() {
 
 	const { data: totalMatches = 0 } = useQuery(trpc.user.getTotalMatches.queryOptions());
 
-	// Passkey queries and mutations
-	const passkeysQuery = useQuery({
-		queryKey: ["passkeys"],
-		queryFn: async () => {
-			const { data, error } = await authClient.passkey.listUserPasskeys({});
-			if (error) {
-				throw new Error(error.message || "Failed to load passkeys");
-			}
-			return data;
-		},
-	});
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// // Passkey queries and mutations
+	// const passkeysQuery = useQuery({
+	// 	queryKey: ["passkeys"],
+	// 	queryFn: async () => {
+	// 		const { data, error } = await authClient.passkey.listUserPasskeys({});
+	// 		if (error) {
+	// 			throw new Error(error.message || "Failed to load passkeys");
+	// 		}
+	// 		return data;
+	// 	},
+	// });
 
 	// Sessions query
 	const sessionsQuery = useQuery({
@@ -100,83 +110,85 @@ function ProfilePage() {
 		},
 	});
 
-	const addPasskeyMutation = useMutation({
-		mutationFn: async (name?: string) => {
-			try {
-				const result = await authClient.passkey.addPasskey({
-					name,
-				});
-				const { data, error } = result;
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// const addPasskeyMutation = useMutation({
+	// 	mutationFn: async (name?: string) => {
+	// 		try {
+	// 			const result = await authClient.passkey.addPasskey({
+	// 				name,
+	// 			});
+	// 			const { data, error } = result;
+	//
+	// 			// Passkey responses always return data object, even on error
+	// 			if (error || (data && typeof data === "object" && "error" in data && data.error)) {
+	// 				const errorMessage =
+	// 					error?.message ||
+	// 					(data && typeof data === "object" && "error" in data && data.error
+	// 						? (data.error as { message?: string }).message
+	// 						: undefined) ||
+	// 					"Failed to add passkey";
+	// 				console.error("Passkey add error:", errorMessage);
+	// 				throw new Error(errorMessage);
+	// 			}
+	// 			return data;
+	// 		} catch (err) {
+	// 			console.error("Exception in addPasskey:", err);
+	// 			throw err;
+	// 		}
+	// 	},
+	// 	mutationKey: ["addPasskey"],
+	// 	onSuccess: () => {
+	// 		void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
+	// 		toast.success("Passkey added successfully");
+	// 	},
+	// 	onError: (err) => {
+	// 		console.error("Add passkey error:", err);
+	// 		toast.error(err instanceof Error ? err.message : "Failed to add passkey");
+	// 	},
+	// 	onSettled: () => {
+	// 		// Reset mutation state after completion (success or error)
+	// 		addPasskeyMutation.reset();
+	// 	},
+	// });
 
-				// Passkey responses always return data object, even on error
-				if (error || (data && typeof data === "object" && "error" in data && data.error)) {
-					const errorMessage =
-						error?.message ||
-						(data && typeof data === "object" && "error" in data && data.error
-							? (data.error as { message?: string }).message
-							: undefined) ||
-						"Failed to add passkey";
-					console.error("Passkey add error:", errorMessage);
-					throw new Error(errorMessage);
-				}
-				return data;
-			} catch (err) {
-				console.error("Exception in addPasskey:", err);
-				throw err;
-			}
-		},
-		mutationKey: ["addPasskey"],
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			toast.success("Passkey added successfully");
-		},
-		onError: (err) => {
-			console.error("Add passkey error:", err);
-			toast.error(err instanceof Error ? err.message : "Failed to add passkey");
-		},
-		onSettled: () => {
-			// Reset mutation state after completion (success or error)
-			addPasskeyMutation.reset();
-		},
-	});
+	// const deletePasskeyMutation = useMutation({
+	// 	mutationFn: async (id: string) => {
+	// 		const { data, error } = await authClient.passkey.deletePasskey({ id });
+	// 		if (error) {
+	// 			throw new Error(error.message || "Failed to delete passkey");
+	// 		}
+	// 		return data;
+	// 	},
+	// 	onSuccess: () => {
+	// 		void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
+	// 		toast.success("Passkey deleted successfully");
+	// 	},
+	// 	onError: (err) => {
+	// 		toast.error(err instanceof Error ? err.message : "Failed to delete passkey");
+	// 	},
+	// });
 
-	const deletePasskeyMutation = useMutation({
-		mutationFn: async (id: string) => {
-			const { data, error } = await authClient.passkey.deletePasskey({ id });
-			if (error) {
-				throw new Error(error.message || "Failed to delete passkey");
-			}
-			return data;
-		},
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			toast.success("Passkey deleted successfully");
-		},
-		onError: (err) => {
-			toast.error(err instanceof Error ? err.message : "Failed to delete passkey");
-		},
-	});
-
-	const updatePasskeyMutation = useMutation({
-		mutationFn: async ({ id, name }: { id: string; name: string }) => {
-			const { data, error } = await authClient.passkey.updatePasskey({
-				id,
-				name,
-			});
-			if (error) {
-				throw new Error(error.message || "Failed to update passkey");
-			}
-			return data;
-		},
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
-			setEditingPasskey(null);
-			toast.success("Passkey updated successfully");
-		},
-		onError: (err) => {
-			toast.error(err instanceof Error ? err.message : "Failed to update passkey");
-		},
-	});
+	// const updatePasskeyMutation = useMutation({
+	// 	mutationFn: async ({ id, name }: { id: string; name: string }) => {
+	// 		const { data, error } = await authClient.passkey.updatePasskey({
+	// 			id,
+	// 			name,
+	// 		});
+	// 		if (error) {
+	// 			throw new Error(error.message || "Failed to update passkey");
+	// 		}
+	// 		return data;
+	// 	},
+	// 	onSuccess: () => {
+	// 		void queryClient.invalidateQueries({ queryKey: ["passkeys"] });
+	// 		setEditingPasskey(null);
+	// 		toast.success("Passkey updated successfully");
+	// 	},
+	// 	onError: (err) => {
+	// 		toast.error(err instanceof Error ? err.message : "Failed to update passkey");
+	// 	},
+	// });
 
 	const revokeOtherSessionsMutation = useMutation({
 		mutationFn: async () => {
@@ -324,8 +336,10 @@ function ProfilePage() {
 					</Card>
 				</div>
 
+				{/* Passkey support disabled due to Cloudflare Workers CPU limits */}
+				{/* TODO: Re-enable when upgrading to Workers Paid plan */}
 				{/* Passkeys Section */}
-				<div className="bg-muted/50 p-6">
+				{/* <div className="bg-muted/50 p-6">
 					<div className="space-y-4">
 						<div className="flex items-center justify-between">
 							<h3 className="text-lg font-medium">Passkeys</h3>
@@ -432,7 +446,7 @@ function ProfilePage() {
 							</div>
 						)}
 					</div>
-				</div>
+				</div> */}
 
 				{/* Sessions Section */}
 				<div className="bg-muted/50 min-h-[100vh] flex-1 md:min-h-min p-6">
@@ -536,8 +550,10 @@ function ProfilePage() {
 				user={{ id: user.id, name: user.name, email: user.email, image: user.image }}
 			/>
 
+			{/* Passkey support disabled due to Cloudflare Workers CPU limits */}
+			{/* TODO: Re-enable when upgrading to Workers Paid plan */}
 			{/* Edit Passkey Dialog */}
-			{editingPasskey && (
+			{/* {editingPasskey && (
 				<EditPasskeyDialog
 					isOpen={!!editingPasskey}
 					onClose={() => setEditingPasskey(null)}
@@ -549,7 +565,7 @@ function ProfilePage() {
 					currentName={editingPasskey.name}
 					isSaving={updatePasskeyMutation.isPending}
 				/>
-			)}
+			)} */}
 
 			{/* Revoke Other Sessions Dialog */}
 			<Dialog open={isRevokeOtherDialogOpen} onOpenChange={setIsRevokeOtherDialogOpen}>

--- a/apps/worker/src/lib/better-auth.ts
+++ b/apps/worker/src/lib/better-auth.ts
@@ -1,4 +1,6 @@
-import { passkey } from "@better-auth/passkey";
+// Passkey support disabled due to Cloudflare Workers CPU limits
+// TODO: Re-enable when upgrading to Workers Paid plan
+// import { passkey } from "@better-auth/passkey";
 import { betterAuth } from "better-auth";
 import { type DB, drizzleAdapter } from "better-auth/adapters/drizzle";
 import { organization } from "better-auth/plugins";
@@ -57,23 +59,32 @@ export function createAuth({
 	const hasAnySocialProviders =
 		(githubClientId && githubClientSecret) || (googleClientId && googleClientSecret);
 
-	// Determine rpID and origin for passkey
-	const getRpID = (originUrl?: string) => {
-		if (originUrl) {
-			try {
-				const url = new URL(originUrl);
-				return url.hostname;
-			} catch {
-				return "localhost";
-			}
-		}
-		return "localhost";
-	};
-
-	const passkeyOrigin = !(origin?.includes("127.0.0.1") || origin?.includes("localhost"))
-		? origin
-		: "http://localhost:5173";
-	const rpID = getRpID(passkeyOrigin);
+	// Passkey support disabled due to Cloudflare Workers CPU limits
+	// TODO: Re-enable when upgrading to Workers Paid plan
+	// const getPasskeyPlugin = () => {
+	// 	const getRpID = (originUrl?: string) => {
+	// 		if (originUrl) {
+	// 			try {
+	// 				return new URL(originUrl).hostname;
+	// 			} catch {
+	// 				return "localhost";
+	// 			}
+	// 		}
+	// 		return "localhost";
+	// 	};
+	//
+	// 	const passkeyOrigin = !(origin?.includes("127.0.0.1") || origin?.includes("localhost"))
+	// 		? origin
+	// 		: "http://localhost:5173";
+	//
+	// 	return passkey({
+	// 		rpID: getRpID(passkeyOrigin),
+	// 		rpName: "Scorebrawl",
+	// 		origin: passkeyOrigin,
+	// 	});
+	// };
+	//
+	// const passkeyPlugin = getPasskeyPlugin();
 
 	return betterAuth({
 		database: drizzleAdapter(db, {
@@ -210,11 +221,9 @@ export function createAuth({
 					console.log(`Invitation for organization ${organization.name} sent to ${email}`);
 				},
 			}),
-			passkey({
-				rpID,
-				rpName: "Scorebrawl",
-				origin: passkeyOrigin,
-			}),
+			// Passkey support disabled due to Cloudflare Workers CPU limits
+			// TODO: Re-enable when upgrading to Workers Paid plan
+			// ...(passkeyPlugin ? [passkeyPlugin] : []),
 		],
 	});
 }


### PR DESCRIPTION
## Summary

Disables passkey authentication to resolve 503 errors caused by Cloudflare Workers Free tier CPU limits.

## Problem

The better-auth passkey plugin performs CPU-intensive WebAuthn cryptographic operations that exceed the Cloudflare Workers Free tier CPU limit (10ms), causing 503 errors on `/api/auth/passkey/*` endpoints.

## Changes

- **Backend**: Comment out passkey plugin import and configuration in `better-auth.ts`
- **Frontend**: Comment out passkey UI in sign-in form (`sign-in-form.tsx`) and profile page (`profile.tsx`)
- **Config**: Update `nodejs_compat` to `nodejs_compat_v2` in wrangler.jsonc (recommended for better-auth)

## Notes

- All passkey code is **preserved as comments** with `TODO: Re-enable when upgrading to Workers Paid plan` markers
- Database schema for passkeys remains intact (no migrations needed)
- Re-enablement requires upgrading to Workers Paid plan ($5/mo) which increases CPU limit to 30ms