### PR TITLE
fix: prefetch season data in matches route loader

### DIFF
--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/matches.tsx
@@ -15,6 +15,7 @@ import { RemoveMatchDialog } from "@/components/match/remove-match-dialog";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "@/components/ui/button";
 import { z } from "zod";
+import { queryClient } from "@/lib/query-client";
 
 const matchesSearchSchema = z.object({
 	addMatch: z.boolean().optional(),
@@ -26,7 +27,12 @@ export const Route = createFileRoute(
 	component: MatchesPage,
 	validateSearch: matchesSearchSchema,
 	loader: async ({ params }) => {
-		return { slug: params.slug, seasonSlug: params.seasonSlug };
+		const { seasonSlug } = params;
+		await queryClient.ensureQueryData({
+			queryKey: ["season", seasonSlug],
+			queryFn: () => trpcClient.season.getBySlug.query({ seasonSlug }),
+		});
+		return { slug: params.slug, seasonSlug };
 	},
 });
 


### PR DESCRIPTION
## Summary
- Fixed issue where navigating directly to `/leagues/{slug}/seasons/{seasonSlug}/matches` showed empty matches list until refresh
- Added `queryClient.ensureQueryData()` in route loader to prefetch season data before component renders

## Problem
When navigating directly to the matches page URL, the `seasonId` was fetched via `useQuery` in the component. This caused `useMatches` to receive an empty `seasonId` on initial render, resulting in no matches being displayed until the query completed.

## Solution
Prefetch the season data in the route's `loader` function using `ensureQueryData`, ensuring the data is available in React Query cache immediately when the component mounts.