### PR TITLE
fix: eliminate N+1 queries in getRivalTeams and getRecentMatches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ out
 .nuxt
 dist
 
+# tanstack
+apps/web/.tanstack/
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,21 @@ Always use **catalog** for workspace dependencies. Define versions in root `pack
 const userId = ctx.authentication.user.id;
 ```
 
+### Query Performance
+
+**Never N+1 queries** - Cloudflare Workers have strict CPU limits. Querying inside loops causes `Worker exceeded CPU time limit` errors.
+
+```typescript
+// BAD - N queries
+const items = await db.select().from(x).where(...);
+await Promise.all(items.map(i => db.select().from(y).where(...)));
+
+// GOOD - 1 query with join
+const data = await db.select({...}).from(x).leftJoin(y, ...);
+```
+
+Always use joins/subqueries. Fetch related data in single round-trip.
+
 ## Hono Route Validation
 
 Always validate headers, payload (body), and search params in Hono routes using **@hono/zod-validator**:


### PR DESCRIPTION
## Summary

Fixes 'Worker exceeded CPU time limit' errors on team pages by eliminating N+1 query patterns.

## Changes

**:**

- : Replaced loop of N queries with single self-join query (1 query instead of N+1)
- : Replaced loop with 2 efficient queries instead of N+1

## Impact

For a team with 100 matches:
- Before: 100+ database queries per function
- After: 1-2 queries total

This significantly reduces CPU usage and prevents timeout errors on team profile pages.