### PR TITLE
fix: resolve Worker CPU time limit errors

### DIFF
--- a/apps/web/src/lib/trpc.ts
+++ b/apps/web/src/lib/trpc.ts
@@ -1,10 +1,5 @@
 import type { TRPCRouter } from "@coding-cowboys/scorebrawl-worker/trpc";
-import {
-	createTRPCClient,
-	httpBatchStreamLink,
-	httpSubscriptionLink,
-	splitLink,
-} from "@trpc/client";
+import { createTRPCClient, httpLink, httpSubscriptionLink, splitLink } from "@trpc/client";
 import type { inferRouterOutputs } from "@trpc/server";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
 import superjson from "superjson";
@@ -21,7 +16,7 @@ export const trpcClient = createTRPCClient<TRPCRouter>({
 				transformer: superjson,
 				url: "/api/trpc",
 			}),
-			false: httpBatchStreamLink({
+			false: httpLink({
 				transformer: superjson,
 				url: "/api/trpc",
 			}),

--- a/apps/worker/src/repositories/match-repository.ts
+++ b/apps/worker/src/repositories/match-repository.ts
@@ -648,61 +648,62 @@ export const getBySeasonId = async ({
 };
 
 export const getMatchWithPlayers = async ({ db, matchId }: { db: DrizzleDB; matchId: string }) => {
-	const matchData = await db
-		.select({
-			id: match.id,
-			seasonId: match.seasonId,
-			homeScore: match.homeScore,
-			awayScore: match.awayScore,
-			createdAt: match.createdAt,
-		})
-		.from(match)
-		.where(eq(match.id, matchId))
-		.limit(1);
+	// Get match data and all related players/teams in parallel
+	const [matchRows, players, teams] = await Promise.all([
+		db
+			.select({
+				id: match.id,
+				seasonId: match.seasonId,
+				homeScore: match.homeScore,
+				awayScore: match.awayScore,
+				createdAt: match.createdAt,
+			})
+			.from(match)
+			.where(eq(match.id, matchId))
+			.limit(1),
+		db
+			.select({
+				id: matchPlayer.id,
+				seasonPlayerId: matchPlayer.seasonPlayerId,
+				homeTeam: matchPlayer.homeTeam,
+				result: matchPlayer.result,
+				scoreBefore: matchPlayer.scoreBefore,
+				scoreAfter: matchPlayer.scoreAfter,
+				name: user.name,
+				image: user.image,
+			})
+			.from(matchPlayer)
+			.innerJoin(seasonPlayer, eq(matchPlayer.seasonPlayerId, seasonPlayer.id))
+			.innerJoin(player, eq(seasonPlayer.playerId, player.id))
+			.innerJoin(user, eq(player.userId, user.id))
+			.where(eq(matchPlayer.matchId, matchId)),
+		db
+			.select({
+				id: matchTeam.id,
+				seasonTeamId: matchTeam.seasonTeamId,
+				result: matchTeam.result,
+				teamName: leagueTeam.name,
+				teamLogo: leagueTeam.logo,
+			})
+			.from(matchTeam)
+			.innerJoin(seasonTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
+			.innerJoin(leagueTeam, eq(seasonTeam.leagueTeamId, leagueTeam.id))
+			.where(eq(matchTeam.matchId, matchId))
+			.orderBy(matchTeam.createdAt),
+	]);
 
-	if (!matchData[0]) return null;
-
-	// Get teams for this match (ordered by creation - home first, away second)
-	const teams = await db
-		.select({
-			id: matchTeam.id,
-			seasonTeamId: matchTeam.seasonTeamId,
-			result: matchTeam.result,
-			teamName: leagueTeam.name,
-			teamLogo: leagueTeam.logo,
-		})
-		.from(matchTeam)
-		.innerJoin(seasonTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
-		.innerJoin(leagueTeam, eq(seasonTeam.leagueTeamId, leagueTeam.id))
-		.where(eq(matchTeam.matchId, matchId))
-		.orderBy(matchTeam.createdAt);
+	if (!matchRows[0]) return null;
+	const matchData = matchRows[0];
 
 	// Determine which team is home vs away based on result and score
 	const homeTeamData =
-		matchData[0].homeScore > matchData[0].awayScore
+		matchData.homeScore > matchData.awayScore
 			? teams.find((t) => t.result === "W")
-			: matchData[0].homeScore < matchData[0].awayScore
+			: matchData.homeScore < matchData.awayScore
 				? teams.find((t) => t.result === "L")
 				: teams[0]; // Draw - use first (home was inserted first)
 
 	const awayTeamData = teams.find((t) => t.id !== homeTeamData?.id);
-
-	const players = await db
-		.select({
-			id: matchPlayer.id,
-			seasonPlayerId: matchPlayer.seasonPlayerId,
-			homeTeam: matchPlayer.homeTeam,
-			result: matchPlayer.result,
-			scoreBefore: matchPlayer.scoreBefore,
-			scoreAfter: matchPlayer.scoreAfter,
-			name: user.name,
-			image: user.image,
-		})
-		.from(matchPlayer)
-		.innerJoin(seasonPlayer, eq(matchPlayer.seasonPlayerId, seasonPlayer.id))
-		.innerJoin(player, eq(seasonPlayer.playerId, player.id))
-		.innerJoin(user, eq(player.userId, user.id))
-		.where(eq(matchPlayer.matchId, matchId));
 
 	// Add team info to players based on homeTeam flag
 	const playersWithTeam = players.map((p) => ({
@@ -712,7 +713,7 @@ export const getMatchWithPlayers = async ({ db, matchId }: { db: DrizzleDB; matc
 	}));
 
 	return {
-		...matchData[0],
+		...matchData,
 		players: playersWithTeam,
 	};
 };

--- a/apps/worker/src/repositories/season-player-repository.ts
+++ b/apps/worker/src/repositories/season-player-repository.ts
@@ -25,118 +25,96 @@ export const findAll = async ({ db, seasonId }: { db: DrizzleDB; seasonId: strin
 };
 
 export const getStanding = async ({ db, seasonId }: { db: DrizzleDB; seasonId: string }) => {
-	// Pre-aggregate match stats in a single query to avoid correlated subqueries
-	const matchStats = db
-		.select({
-			seasonPlayerId: matchPlayer.seasonPlayerId,
-			matchCount: sql<number>`count(*)`.as("match_count"),
-			winCount: sql<number>`sum(case when ${matchPlayer.result} = 'W' then 1 else 0 end)`.as(
-				"win_count"
-			),
-			lossCount: sql<number>`sum(case when ${matchPlayer.result} = 'L' then 1 else 0 end)`.as(
-				"loss_count"
-			),
-			drawCount: sql<number>`sum(case when ${matchPlayer.result} = 'D' then 1 else 0 end)`.as(
-				"draw_count"
-			),
-		})
-		.from(matchPlayer)
-		.groupBy(matchPlayer.seasonPlayerId)
-		.as("match_stats");
-
-	const results = await db
-		.select({
-			id: seasonPlayer.id,
-			seasonId: seasonPlayer.seasonId,
-			playerId: seasonPlayer.playerId,
-			score: seasonPlayer.score,
-			name: user.name,
-			image: user.image,
-			userId: player.userId,
-			matchCount: sql<number>`coalesce(${matchStats.matchCount}, 0)`,
-			winCount: sql<number>`coalesce(${matchStats.winCount}, 0)`,
-			lossCount: sql<number>`coalesce(${matchStats.lossCount}, 0)`,
-			drawCount: sql<number>`coalesce(${matchStats.drawCount}, 0)`,
-		})
-		.from(seasonPlayer)
-		.innerJoin(player, eq(seasonPlayer.playerId, player.id))
-		.innerJoin(user, eq(player.userId, user.id))
-		.leftJoin(matchStats, eq(seasonPlayer.id, matchStats.seasonPlayerId))
-		.where(eq(seasonPlayer.seasonId, seasonId))
-		.orderBy(desc(seasonPlayer.score));
-
-	// Calculate point differences for today's matches (final implementation)
-	const pointDiff: { seasonPlayerId: string; pointDiff: number }[] = [];
-
-	try {
-		// Get all matches from today using a more robust date comparison
-		const todayMatches = await db
-			.select({
-				seasonPlayerId: matchPlayer.seasonPlayerId,
-				scoreAfter: matchPlayer.scoreAfter,
-				scoreBefore: matchPlayer.scoreBefore,
-				createdAt: matchPlayer.createdAt,
-			})
-			.from(matchPlayer)
-			.innerJoin(seasonPlayer, eq(matchPlayer.seasonPlayerId, seasonPlayer.id))
-			.where(
-				and(
-					eq(seasonPlayer.seasonId, seasonId),
-					// Convert Unix timestamp to date string for proper comparison
-					sql`strftime('%Y-%m-%d', datetime(${matchPlayer.createdAt}, 'unixepoch')) = strftime('%Y-%m-%d', 'now', 'localtime')`
-				)
-			);
-
-		// Calculate net point differences for each player today
-		const pointDiffMap = new Map<string, number>();
-		for (const match of todayMatches) {
-			const currentDiff = pointDiffMap.get(match.seasonPlayerId) || 0;
-			const matchDiff = match.scoreAfter - match.scoreBefore;
-			pointDiffMap.set(match.seasonPlayerId, currentDiff + matchDiff);
-		}
-
-		// Convert to array format
-		for (const [seasonPlayerId, diff] of pointDiffMap) {
-			pointDiff.push({ seasonPlayerId, pointDiff: diff });
-		}
-	} catch (error) {
-		console.error("Error calculating point diff:", error);
-		// Continue with empty pointDiff array if there's an error
-	}
-
-	// Get recent match form (last 5 results per player) using window function
-	const recentForms = await db.all<{ seasonPlayerId: string; result: string }>(sql`
-		SELECT season_player_id as seasonPlayerId, result
-		FROM (
-			SELECT 
+	// Single raw SQL query that computes standings, today's point diff, and recent form
+	const rows = await db.all<{
+		id: string;
+		seasonId: string;
+		playerId: string;
+		score: number;
+		name: string;
+		image: string | null;
+		userId: string;
+		matchCount: number;
+		winCount: number;
+		lossCount: number;
+		drawCount: number;
+		todayPointDiff: number;
+		recentResults: string | null;
+	}>(sql`
+		SELECT
+			sp.id,
+			sp.season_id as seasonId,
+			sp.player_id as playerId,
+			sp.score,
+			u.name,
+			u.image,
+			p.user_id as userId,
+			COALESCE(stats.match_count, 0) as matchCount,
+			COALESCE(stats.win_count, 0) as winCount,
+			COALESCE(stats.loss_count, 0) as lossCount,
+			COALESCE(stats.draw_count, 0) as drawCount,
+			COALESCE(today.point_diff, 0) as todayPointDiff,
+			form.recent_results as recentResults
+		FROM season_player sp
+		INNER JOIN player p ON sp.player_id = p.id
+		INNER JOIN user u ON p.user_id = u.id
+		LEFT JOIN (
+			SELECT
 				mp.season_player_id,
-				mp.result,
-				ROW_NUMBER() OVER (PARTITION BY mp.season_player_id ORDER BY mp.created_at DESC) as rn
+				COUNT(*) as match_count,
+				SUM(CASE WHEN mp.result = 'W' THEN 1 ELSE 0 END) as win_count,
+				SUM(CASE WHEN mp.result = 'L' THEN 1 ELSE 0 END) as loss_count,
+				SUM(CASE WHEN mp.result = 'D' THEN 1 ELSE 0 END) as draw_count
 			FROM match_player mp
-			INNER JOIN season_player sp ON mp.season_player_id = sp.id
-			WHERE sp.season_id = ${seasonId}
-		)
-		WHERE rn <= 5
-		ORDER BY season_player_id, rn
+			INNER JOIN season_player sp2 ON mp.season_player_id = sp2.id
+			WHERE sp2.season_id = ${seasonId}
+			GROUP BY mp.season_player_id
+		) stats ON sp.id = stats.season_player_id
+		LEFT JOIN (
+			SELECT
+				mp.season_player_id,
+				SUM(mp.score_after - mp.score_before) as point_diff
+			FROM match_player mp
+			INNER JOIN season_player sp2 ON mp.season_player_id = sp2.id
+			WHERE sp2.season_id = ${seasonId}
+			AND strftime('%Y-%m-%d', datetime(mp.created_at, 'unixepoch')) = strftime('%Y-%m-%d', 'now', 'localtime')
+			GROUP BY mp.season_player_id
+		) today ON sp.id = today.season_player_id
+		LEFT JOIN (
+			SELECT
+				season_player_id,
+				GROUP_CONCAT(result, '') as recent_results
+			FROM (
+				SELECT
+					mp.season_player_id,
+					mp.result,
+					ROW_NUMBER() OVER (PARTITION BY mp.season_player_id ORDER BY mp.created_at DESC) as rn
+				FROM match_player mp
+				INNER JOIN season_player sp2 ON mp.season_player_id = sp2.id
+				WHERE sp2.season_id = ${seasonId}
+			)
+			WHERE rn <= 5
+			GROUP BY season_player_id
+		) form ON sp.id = form.season_player_id
+		WHERE sp.season_id = ${seasonId}
+		ORDER BY sp.score DESC
 	`);
 
-	// Group form data by player
-	const formMap = recentForms.reduce(
-		(acc, match) => {
-			if (!acc[match.seasonPlayerId]) {
-				acc[match.seasonPlayerId] = [];
-			}
-			acc[match.seasonPlayerId].push(match.result as "W" | "D" | "L");
-			return acc;
-		},
-		{} as Record<string, ("W" | "D" | "L")[]>
-	);
-
-	return results.map((r, index) => ({
-		...r,
+	return rows.map((r, index) => ({
+		id: r.id,
+		seasonId: r.seasonId,
+		playerId: r.playerId,
+		score: r.score,
+		name: r.name,
+		image: r.image,
+		userId: r.userId,
+		matchCount: r.matchCount,
+		winCount: r.winCount,
+		lossCount: r.lossCount,
+		drawCount: r.drawCount,
 		rank: index + 1,
-		pointDiff: pointDiff.find((pd) => pd.seasonPlayerId === r.id)?.pointDiff ?? 0,
-		form: formMap[r.id] || [],
+		pointDiff: r.todayPointDiff,
+		form: r.recentResults ? (r.recentResults.split("") as ("W" | "D" | "L")[]) : [],
 	}));
 };
 

--- a/apps/worker/src/repositories/season-repository.ts
+++ b/apps/worker/src/repositories/season-repository.ts
@@ -39,53 +39,54 @@ export interface SeasonEditInput {
 }
 
 export const getCountInfo = async ({ db, seasonSlug }: { db: DrizzleDB; seasonSlug: string }) => {
-	const [matchCount] = await db
-		.select({ count: sql<number>`count(*)` })
-		.from(match)
-		.innerJoin(season, eq(match.seasonId, season.id))
-		.where(eq(season.slug, seasonSlug));
-
-	const [teamCount] = await db
-		.select({ count: sql<number>`count(*)` })
-		.from(leagueTeam)
-		.innerJoin(organization, eq(leagueTeam.leagueId, organization.id))
-		.innerJoin(season, eq(season.leagueId, organization.id))
-		.where(eq(season.slug, seasonSlug));
-
-	const [playerCount] = await db
-		.select({ count: sql<number>`count(*)` })
-		.from(seasonPlayer)
-		.innerJoin(season, eq(seasonPlayer.seasonId, season.id))
-		.where(eq(season.slug, seasonSlug));
+	const [counts] = await db
+		.select({
+			matchCount: sql<number>`(
+				SELECT count(*) FROM ${match}
+				INNER JOIN ${season} s ON ${match.seasonId} = s.id
+				WHERE s.slug = ${seasonSlug}
+			)`,
+			teamCount: sql<number>`(
+				SELECT count(*) FROM ${leagueTeam}
+				WHERE ${leagueTeam.leagueId} = (SELECT s.league_id FROM ${season} s WHERE s.slug = ${seasonSlug})
+			)`,
+			playerCount: sql<number>`(
+				SELECT count(*) FROM ${seasonPlayer}
+				INNER JOIN ${season} s ON ${seasonPlayer.seasonId} = s.id
+				WHERE s.slug = ${seasonSlug}
+			)`,
+		})
+		.from(sql`(SELECT 1)`);
 
 	return {
-		matchCount: matchCount?.count || 0,
-		teamCount: teamCount?.count || 0,
-		playerCount: playerCount?.count || 0,
+		matchCount: counts?.matchCount || 0,
+		teamCount: counts?.teamCount || 0,
+		playerCount: counts?.playerCount || 0,
 	};
 };
 
 export const getCountInfoById = async ({ db, seasonId }: { db: DrizzleDB; seasonId: string }) => {
-	const [matchCount] = await db
-		.select({ count: sql<number>`count(*)` })
-		.from(match)
-		.where(eq(match.seasonId, seasonId));
-
-	const [teamCount] = await db
-		.select({ count: sql<number>`count(*)` })
-		.from(leagueTeam)
-		.innerJoin(season, eq(season.leagueId, leagueTeam.leagueId))
-		.where(eq(season.id, seasonId));
-
-	const [playerCount] = await db
-		.select({ count: sql<number>`count(*)` })
-		.from(seasonPlayer)
-		.where(eq(seasonPlayer.seasonId, seasonId));
+	const [counts] = await db
+		.select({
+			matchCount: sql<number>`(
+				SELECT count(*) FROM ${match}
+				WHERE ${match.seasonId} = ${seasonId}
+			)`,
+			teamCount: sql<number>`(
+				SELECT count(*) FROM ${leagueTeam}
+				WHERE ${leagueTeam.leagueId} = (SELECT s.league_id FROM ${season} s WHERE s.id = ${seasonId})
+			)`,
+			playerCount: sql<number>`(
+				SELECT count(*) FROM ${seasonPlayer}
+				WHERE ${seasonPlayer.seasonId} = ${seasonId}
+			)`,
+		})
+		.from(sql`(SELECT 1)`);
 
 	return {
-		matchCount: matchCount?.count || 0,
-		teamCount: teamCount?.count || 0,
-		playerCount: playerCount?.count || 0,
+		matchCount: counts?.matchCount || 0,
+		teamCount: counts?.teamCount || 0,
+		playerCount: counts?.playerCount || 0,
 	};
 };
 

--- a/apps/worker/src/repositories/season-team-repository.ts
+++ b/apps/worker/src/repositories/season-team-repository.ts
@@ -1,108 +1,82 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { DrizzleDB } from "../db";
-import {
-	seasonTeam,
-	matchTeam,
-	leagueTeam,
-	leagueTeamPlayer,
-	player,
-} from "../db/schema/league-schema";
+import { seasonTeam, leagueTeam, leagueTeamPlayer, player } from "../db/schema/league-schema";
 import { user } from "../db/schema/auth-schema";
 
 export const getStanding = async ({ db, seasonId }: { db: DrizzleDB; seasonId: string }) => {
-	const results = await db
-		.select({
-			id: seasonTeam.id,
-			seasonId: seasonTeam.seasonId,
-			leagueTeamId: seasonTeam.leagueTeamId,
-			score: seasonTeam.score,
-			name: leagueTeam.name,
-			logo: leagueTeam.logo,
-			matchCount: sql<number>`(
-				select count(*) from ${matchTeam}
-				where ${matchTeam.seasonTeamId} = ${seasonTeam.id}
-			)`,
-			winCount: sql<number>`(
-				select count(*) from ${matchTeam} 
-				where ${matchTeam.seasonTeamId} = ${seasonTeam.id} 
-				and ${matchTeam.result} = 'W'
-			)`,
-			lossCount: sql<number>`(
-				select count(*) from ${matchTeam} 
-				where ${matchTeam.seasonTeamId} = ${seasonTeam.id} 
-				and ${matchTeam.result} = 'L'
-			)`,
-			drawCount: sql<number>`(
-				select count(*) from ${matchTeam} 
-				where ${matchTeam.seasonTeamId} = ${seasonTeam.id} 
-				and ${matchTeam.result} = 'D'
-			)`,
-		})
-		.from(seasonTeam)
-		.innerJoin(leagueTeam, eq(seasonTeam.leagueTeamId, leagueTeam.id))
-		.where(eq(seasonTeam.seasonId, seasonId))
-		.orderBy(desc(seasonTeam.score));
+	// Single query for standings with stats, today's point diff, and recent form
+	const rows = await db.all<{
+		id: string;
+		seasonId: string;
+		leagueTeamId: string;
+		score: number;
+		name: string;
+		logo: string | null;
+		matchCount: number;
+		winCount: number;
+		lossCount: number;
+		drawCount: number;
+		todayPointDiff: number;
+		recentResults: string | null;
+	}>(sql`
+		SELECT
+			st.id,
+			st.season_id as seasonId,
+			st.league_team_id as leagueTeamId,
+			st.score,
+			lt.name,
+			lt.logo,
+			COALESCE(stats.match_count, 0) as matchCount,
+			COALESCE(stats.win_count, 0) as winCount,
+			COALESCE(stats.loss_count, 0) as lossCount,
+			COALESCE(stats.draw_count, 0) as drawCount,
+			COALESCE(today.point_diff, 0) as todayPointDiff,
+			form.recent_results as recentResults
+		FROM season_team st
+		INNER JOIN league_team lt ON st.league_team_id = lt.id
+		LEFT JOIN (
+			SELECT
+				mt.season_team_id,
+				COUNT(*) as match_count,
+				SUM(CASE WHEN mt.result = 'W' THEN 1 ELSE 0 END) as win_count,
+				SUM(CASE WHEN mt.result = 'L' THEN 1 ELSE 0 END) as loss_count,
+				SUM(CASE WHEN mt.result = 'D' THEN 1 ELSE 0 END) as draw_count
+			FROM match_team mt
+			INNER JOIN season_team st2 ON mt.season_team_id = st2.id
+			WHERE st2.season_id = ${seasonId}
+			GROUP BY mt.season_team_id
+		) stats ON st.id = stats.season_team_id
+		LEFT JOIN (
+			SELECT
+				mt.season_team_id,
+				SUM(mt.score_after - mt.score_before) as point_diff
+			FROM match_team mt
+			INNER JOIN season_team st2 ON mt.season_team_id = st2.id
+			WHERE st2.season_id = ${seasonId}
+			AND strftime('%Y-%m-%d', datetime(mt.created_at, 'unixepoch')) = strftime('%Y-%m-%d', 'now', 'localtime')
+			GROUP BY mt.season_team_id
+		) today ON st.id = today.season_team_id
+		LEFT JOIN (
+			SELECT
+				season_team_id,
+				GROUP_CONCAT(result, '') as recent_results
+			FROM (
+				SELECT
+					mt.season_team_id,
+					mt.result,
+					ROW_NUMBER() OVER (PARTITION BY mt.season_team_id ORDER BY mt.created_at DESC) as rn
+				FROM match_team mt
+				INNER JOIN season_team st2 ON mt.season_team_id = st2.id
+				WHERE st2.season_id = ${seasonId}
+			)
+			WHERE rn <= 5
+			GROUP BY season_team_id
+		) form ON st.id = form.season_team_id
+		WHERE st.season_id = ${seasonId}
+		ORDER BY st.score DESC
+	`);
 
-	// Calculate point differences for today's matches
-	const pointDiff: { seasonTeamId: string; pointDiff: number }[] = [];
-
-	try {
-		const todayMatches = await db
-			.select({
-				seasonTeamId: matchTeam.seasonTeamId,
-				scoreAfter: matchTeam.scoreAfter,
-				scoreBefore: matchTeam.scoreBefore,
-				createdAt: matchTeam.createdAt,
-			})
-			.from(matchTeam)
-			.innerJoin(seasonTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
-			.where(
-				and(
-					eq(seasonTeam.seasonId, seasonId),
-					sql`strftime('%Y-%m-%d', datetime(${matchTeam.createdAt}, 'unixepoch')) = strftime('%Y-%m-%d', 'now', 'localtime')`
-				)
-			);
-
-		const pointDiffMap = new Map<string, number>();
-		for (const match of todayMatches) {
-			const currentDiff = pointDiffMap.get(match.seasonTeamId) || 0;
-			const matchDiff = match.scoreAfter - match.scoreBefore;
-			pointDiffMap.set(match.seasonTeamId, currentDiff + matchDiff);
-		}
-
-		for (const [seasonTeamId, diff] of pointDiffMap) {
-			pointDiff.push({ seasonTeamId, pointDiff: diff });
-		}
-	} catch (error) {
-		console.error("Error calculating team point diff:", error);
-	}
-
-	// Get recent match form (last 5 results)
-	const recentForms = await db
-		.select({
-			seasonTeamId: matchTeam.seasonTeamId,
-			result: matchTeam.result,
-			createdAt: matchTeam.createdAt,
-		})
-		.from(matchTeam)
-		.innerJoin(seasonTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
-		.where(eq(seasonTeam.seasonId, seasonId))
-		.orderBy(desc(matchTeam.createdAt));
-
-	const formMap = recentForms.reduce(
-		(acc, match) => {
-			if (!acc[match.seasonTeamId]) {
-				acc[match.seasonTeamId] = [];
-			}
-			if (acc[match.seasonTeamId].length < 5) {
-				acc[match.seasonTeamId].push(match.result as "W" | "D" | "L");
-			}
-			return acc;
-		},
-		{} as Record<string, ("W" | "D" | "L")[]>
-	);
-
-	// Get players for each team using JOIN instead of IN clause to avoid parameter limits
+	// Single query for team players
 	const teamPlayers = await db
 		.select({
 			leagueTeamId: leagueTeamPlayer.leagueTeamId,
@@ -139,11 +113,20 @@ export const getStanding = async ({ db, seasonId }: { db: DrizzleDB; seasonId: s
 		>
 	);
 
-	return results.map((r, index) => ({
-		...r,
+	return rows.map((r, index) => ({
+		id: r.id,
+		seasonId: r.seasonId,
+		leagueTeamId: r.leagueTeamId,
+		score: r.score,
+		name: r.name,
+		logo: r.logo,
+		matchCount: r.matchCount,
+		winCount: r.winCount,
+		lossCount: r.lossCount,
+		drawCount: r.drawCount,
 		rank: index + 1,
-		pointDiff: pointDiff.find((pd) => pd.seasonTeamId === r.id)?.pointDiff ?? 0,
-		form: formMap[r.id] || [],
+		pointDiff: r.todayPointDiff,
+		form: r.recentResults ? (r.recentResults.split("") as ("W" | "D" | "L")[]) : [],
 		players: playersMap[r.leagueTeamId] || [],
 	}));
 };

--- a/apps/worker/src/trpc/router/season-router.ts
+++ b/apps/worker/src/trpc/router/season-router.ts
@@ -38,10 +38,10 @@ export const seasonRouter = {
 		archived: ctx.season.archived,
 	})),
 
-	getCountInfo: seasonProcedure.query(async ({ ctx, input }) => {
-		return seasonRepository.getCountInfo({
+	getCountInfo: seasonProcedure.query(async ({ ctx }) => {
+		return seasonRepository.getCountInfoById({
 			db: ctx.db,
-			seasonSlug: input.seasonSlug,
+			seasonId: ctx.season.id,
 		});
 	}),
 

--- a/apps/worker/src/trpc/server.ts
+++ b/apps/worker/src/trpc/server.ts
@@ -16,6 +16,8 @@ export const trpcServer = honoTrpcServer({
 			betterAuth,
 			userAssets: c.get("userAssets"),
 			env: c.env,
+			// Per-request cache shared across batched tRPC procedures
+			_cache: new Map<string, unknown>(),
 		};
 	},
 });

--- a/apps/worker/src/trpc/trpc.ts
+++ b/apps/worker/src/trpc/trpc.ts
@@ -90,7 +90,6 @@ const leagueAccessMiddleware = t.middleware(async ({ ctx, next }) => {
 		throw new TRPCError({ code: "UNAUTHORIZED", message: "No active league" });
 	}
 
-	// Verify league exists and user is a member
 	const org = await ctx.db
 		.select({
 			id: organization.id,
@@ -127,7 +126,6 @@ const seasonAccessMiddleware = t.middleware(async ({ ctx, input, next }) => {
 	const seasonSlug = typedInput.seasonSlug;
 	const organizationId = typedCtx.organizationId;
 
-	// Get season with organization verification
 	const comp = await ctx.db
 		.select({
 			id: season.id,


### PR DESCRIPTION
## Summary

- **Disable tRPC batching** — switch from `httpBatchStreamLink` to `httpLink` so each procedure gets its own Worker CPU budget, preventing "Worker exceeded CPU time limit" errors
- **Consolidate DB queries** — reduce per-procedure query count to minimize CPU usage within each request
- **Fix `getCountInfo` SQL bug** — Drizzle `sql` template rendered a JOIN condition incorrectly on D1, causing 500 errors

## Query reductions

| Procedure | Before | After |
|---|---|---|
| `seasonPlayer.getStanding` | 3 sequential queries | 1 raw SQL |
| `seasonTeam.getStanding` | ~7 queries | 1 raw SQL + 1 team players |
| `season.getCountInfo` | 3 queries | 1 query (scalar subqueries) |
| `match.getMatchWithPlayers` | 3 sequential | 3 parallel (`Promise.all`) |

## Why disable batching?

On Cloudflare Workers, a batched tRPC request combines 5 procedures into a single Worker invocation, stacking all CPU costs against one Worker's 10ms/30ms CPU limit. With batching disabled:
- Each procedure gets its own CPU budget
- Failures are isolated
- HTTP/2-3 handles concurrent requests efficiently with minimal latency overhead
- D1 queries are sequential within a Worker anyway, so batching doesn't save round-trip time

## Verified

- All 65 tests pass
- Typecheck clean
- Browser tested: all season page data loads correctly (standings, teams, general info, latest match)