### PR TITLE
Improve standings tables mobile view

### DIFF
--- a/apps/web/src/components/season/standing.tsx
+++ b/apps/web/src/components/season/standing.tsx
@@ -44,15 +44,21 @@ export function Standing({ seasonSlug, leagueSlug }: StandingProps) {
 				<TableHeader className="text-xs">
 					<TableRow>
 						<TableHead>Name</TableHead>
-						<TableHead className="text-center text-muted-foreground">MP</TableHead>
-						<TableHead className="text-center text-muted-foreground">W</TableHead>
-						<TableHead className="text-center text-muted-foreground">D</TableHead>
-						<TableHead className="text-center text-muted-foreground">L</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							MP
+						</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							W
+						</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							D
+						</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							L
+						</TableHead>
 						<TableHead className="text-center">+/-</TableHead>
 						<TableHead className="font-bold text-center">Pts</TableHead>
-						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
-							Last 5
-						</TableHead>
+						<TableHead className="text-center text-muted-foreground">Last 5</TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody className="text-sm">
@@ -73,25 +79,25 @@ export function Standing({ seasonSlug, leagueSlug }: StandingProps) {
 									</div>
 								</TableCell>
 								<TableCell
-									className="text-center text-muted-foreground"
+									className="hidden md:table-cell text-center text-muted-foreground"
 									data-testid={`standing-mp-${item.id}`}
 								>
 									{item.matchCount}
 								</TableCell>
 								<TableCell
-									className="text-center text-muted-foreground"
+									className="hidden md:table-cell text-center text-muted-foreground"
 									data-testid={`standing-wins-${item.id}`}
 								>
 									{item.winCount}
 								</TableCell>
 								<TableCell
-									className="text-center text-muted-foreground"
+									className="hidden md:table-cell text-center text-muted-foreground"
 									data-testid={`standing-draws-${item.id}`}
 								>
 									{item.drawCount}
 								</TableCell>
 								<TableCell
-									className="text-center text-muted-foreground"
+									className="hidden md:table-cell text-center text-muted-foreground"
 									data-testid={`standing-losses-${item.id}`}
 								>
 									{item.lossCount}
@@ -117,7 +123,7 @@ export function Standing({ seasonSlug, leagueSlug }: StandingProps) {
 								>
 									{item.score}
 								</TableCell>
-								<TableCell className="hidden md:table-cell">
+								<TableCell>
 									<FormDots form={item.form} />
 								</TableCell>
 							</>

--- a/apps/web/src/components/season/team-standing.tsx
+++ b/apps/web/src/components/season/team-standing.tsx
@@ -119,15 +119,21 @@ export function TeamStanding({
 				<TableHeader className="text-xs">
 					<TableRow>
 						<TableHead>Team</TableHead>
-						<TableHead className="text-center text-muted-foreground">MP</TableHead>
-						<TableHead className="text-center text-muted-foreground">W</TableHead>
-						<TableHead className="text-center text-muted-foreground">D</TableHead>
-						<TableHead className="text-center text-muted-foreground">L</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							MP
+						</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							W
+						</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							D
+						</TableHead>
+						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
+							L
+						</TableHead>
 						<TableHead className="text-center">+/-</TableHead>
 						<TableHead className="font-bold text-center">Pts</TableHead>
-						<TableHead className="hidden md:table-cell text-center text-muted-foreground">
-							Last 5
-						</TableHead>
+						<TableHead className="text-center text-muted-foreground">Last 5</TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody className="text-sm">
@@ -156,25 +162,25 @@ export function TeamStanding({
 								</div>
 							</TableCell>
 							<TableCell
-								className="text-center text-muted-foreground"
+								className="hidden md:table-cell text-center text-muted-foreground"
 								data-testid={`team-standing-mp-${item.id}`}
 							>
 								{item.matchCount}
 							</TableCell>
 							<TableCell
-								className="text-center text-muted-foreground"
+								className="hidden md:table-cell text-center text-muted-foreground"
 								data-testid={`team-standing-wins-${item.id}`}
 							>
 								{item.winCount}
 							</TableCell>
 							<TableCell
-								className="text-center text-muted-foreground"
+								className="hidden md:table-cell text-center text-muted-foreground"
 								data-testid={`team-standing-draws-${item.id}`}
 							>
 								{item.drawCount}
 							</TableCell>
 							<TableCell
-								className="text-center text-muted-foreground"
+								className="hidden md:table-cell text-center text-muted-foreground"
 								data-testid={`team-standing-losses-${item.id}`}
 							>
 								{item.lossCount}
@@ -200,7 +206,7 @@ export function TeamStanding({
 							>
 								{item.score}
 							</TableCell>
-							<TableCell className="hidden md:table-cell">
+							<TableCell>
 								<FormDots form={item.form} />
 							</TableCell>
 						</TableRow>


### PR DESCRIPTION
Before:
<img width="439" height="858" alt="Screenshot 2026-02-16 at 16 14 10" src="https://github.com/user-attachments/assets/97d05fb0-5a4f-481f-9099-e4912f382c8d" />

After:
<img width="444" height="716" alt="Screenshot 2026-02-16 at 16 20 15" src="https://github.com/user-attachments/assets/5498276b-604a-48e5-a962-75a73aab310e" />
