### PR TITLE
feat: add API keys with Better Auth plugin for external integrations

### DIFF
--- a/apps/e2e/tests/seeded-api-key.spec.ts
+++ b/apps/e2e/tests/seeded-api-key.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, signIn, SEED_USER, SEED_LEAGUE } from "./fixtures/auth";
+
+test.describe("Seeded API Key", () => {
+	test.beforeEach(async ({ page }) => {
+		await signIn(page, SEED_USER.email, SEED_USER.password);
+	});
+
+	test("should create an API key via UI and use it to fetch leagues", async ({ page, request }) => {
+		// Navigate to profile page
+		await page.goto("/profile", { waitUntil: "networkidle" });
+
+		// Click Add API Key button
+		await page.getByTestId("add-api-key-button").click();
+
+		// Fill in the key name and submit
+		await page.getByTestId("api-key-name-input").fill("E2E Test Device");
+		await page.getByTestId("api-key-submit-button").click();
+
+		// Wait for success dialog showing the new key
+		const keyElement = page.getByTestId("new-api-key-value");
+		await expect(keyElement).toBeVisible({ timeout: 10000 });
+
+		// Grab the API key value
+		const apiKey = await keyElement.textContent();
+		expect(apiKey).toBeTruthy();
+		expect(apiKey).toMatch(/^sb_dev/);
+
+		// Close the success dialog
+		await page.getByTestId("api-key-done-button").click();
+
+		// Use the API key to fetch device leagues (without session cookies)
+		const leaguesResponse = await request.get("/api/device/leagues", {
+			headers: { "x-api-key": apiKey! },
+		});
+		expect(leaguesResponse.status()).toBe(200);
+
+		const leaguesData = await leaguesResponse.json();
+		expect(leaguesData.leagues).toBeInstanceOf(Array);
+		expect(leaguesData.leagues.length).toBeGreaterThan(0);
+		expect(leaguesData.leagues.some((l: { slug: string }) => l.slug === SEED_LEAGUE.slug)).toBe(
+			true
+		);
+	});
+
+	test("should reject requests with invalid API key", async ({ request }) => {
+		const response = await request.get("/api/device/leagues", {
+			headers: {
+				"x-api-key":
+					"sb_dev_invalid_key_here_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		});
+		expect(response.status()).toBe(401);
+	});
+
+	test("should reject requests without API key", async ({ request }) => {
+		const response = await request.get("/api/device/leagues");
+		expect(response.status()).toBe(401);
+	});
+});

--- a/apps/web/src/components/devices/create-api-key-dialog.tsx
+++ b/apps/web/src/components/devices/create-api-key-dialog.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@/components/ui/button";
+import { GlowButton, glowColors } from "@/components/ui/glow-button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { useState } from "react";
+
+interface CreateApiKeyDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onCreate: (name: string) => void;
+	isCreating: boolean;
+}
+
+export function CreateApiKeyDialog({
+	isOpen,
+	onClose,
+	onCreate,
+	isCreating,
+}: CreateApiKeyDialogProps) {
+	const [name, setName] = useState("");
+
+	const handleCreate = () => {
+		if (name.trim()) {
+			onCreate(name.trim());
+		}
+	};
+
+	const handleCancel = () => {
+		setName("");
+		onClose();
+	};
+
+	const handleOpenChange = (open: boolean) => {
+		if (!open) {
+			handleCancel();
+		}
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={handleOpenChange}>
+			<DialogContent className="sm:max-w-xl max-h-[95vh] overflow-hidden p-0">
+				{/* Technical Grid Background */}
+				<div className="absolute inset-0 opacity-[0.02] dark:opacity-[0.02] opacity-[0.05]">
+					<div
+						className="w-full h-full"
+						style={{
+							backgroundImage:
+								"radial-gradient(circle at 1px 1px, currentColor 1px, transparent 0)",
+							backgroundSize: "24px 24px",
+						}}
+					/>
+				</div>
+
+				{/* Header */}
+				<DialogHeader className="relative z-10 pb-4 border-b border-border p-6">
+					<div className="flex items-center gap-3">
+						<div className="w-2 h-6 bg-blue-500 rounded-full shadow-lg shadow-blue-500/25" />
+						<DialogTitle className="text-xl font-bold font-mono tracking-tight">
+							Create API Key
+						</DialogTitle>
+					</div>
+					<p className="text-sm text-muted-foreground mt-2">
+						Create an API key for external integrations or companion devices
+					</p>
+				</DialogHeader>
+
+				<div className="relative z-10 overflow-y-auto max-h-[calc(95vh-140px)] p-6">
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							handleCreate();
+						}}
+						className="space-y-6"
+					>
+						<FieldGroup className="space-y-4">
+							<Field>
+								<FieldLabel className="font-mono text-xs font-medium tracking-wide mb-0.5">
+									Key Name
+								</FieldLabel>
+								<Input
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									className="h-8 font-mono focus:border-blue-500 focus:ring-blue-500/20 text-sm"
+									placeholder="My Integration"
+									autoFocus
+									data-testid="api-key-name-input"
+								/>
+								<p className="text-xs text-muted-foreground mt-1">
+									Give your API key a memorable name to identify it later
+								</p>
+							</Field>
+						</FieldGroup>
+
+						{/* Action Buttons */}
+						<div className="flex gap-4 pt-2">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={handleCancel}
+								className="font-mono h-8 text-sm"
+								disabled={isCreating}
+							>
+								Cancel
+							</Button>
+							<GlowButton
+								type="submit"
+								glowColor={glowColors.blue}
+								disabled={isCreating || !name.trim()}
+								className="flex-1 font-mono h-8 text-sm"
+								data-testid="api-key-submit-button"
+							>
+								{isCreating ? "Creating..." : "Create Key"}
+							</GlowButton>
+						</div>
+					</form>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/components/devices/edit-api-key-dialog.tsx
+++ b/apps/web/src/components/devices/edit-api-key-dialog.tsx
@@ -1,0 +1,114 @@
+import { Button } from "@/components/ui/button";
+import { GlowButton, glowColors } from "@/components/ui/glow-button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { useState, useEffect } from "react";
+
+interface EditApiKeyDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onSave: (name: string) => void;
+	currentName: string;
+	isSaving: boolean;
+}
+
+export function EditApiKeyDialog({
+	isOpen,
+	onClose,
+	onSave,
+	currentName,
+	isSaving,
+}: EditApiKeyDialogProps) {
+	const [name, setName] = useState(currentName);
+
+	useEffect(() => {
+		setName(currentName);
+	}, [currentName]);
+
+	const handleSave = () => {
+		if (name.trim()) {
+			onSave(name.trim());
+		}
+	};
+
+	const handleCancel = () => {
+		setName(currentName);
+		onClose();
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
+			<DialogContent className="sm:max-w-xl max-h-[95vh] overflow-hidden p-0">
+				{/* Technical Grid Background */}
+				<div className="absolute inset-0 opacity-[0.02] dark:opacity-[0.02] opacity-[0.05]">
+					<div
+						className="w-full h-full"
+						style={{
+							backgroundImage:
+								"radial-gradient(circle at 1px 1px, currentColor 1px, transparent 0)",
+							backgroundSize: "24px 24px",
+						}}
+					/>
+				</div>
+
+				{/* Header */}
+				<DialogHeader className="relative z-10 pb-4 border-b border-border p-6">
+					<div className="flex items-center gap-3">
+						<div className="w-2 h-6 bg-purple-500 rounded-full shadow-lg shadow-purple-500/25" />
+						<DialogTitle className="text-xl font-bold font-mono tracking-tight">
+							Edit API Key
+						</DialogTitle>
+					</div>
+					<p className="text-sm text-muted-foreground mt-2">Update the name of your API key</p>
+				</DialogHeader>
+
+				<div className="relative z-10 overflow-y-auto max-h-[calc(95vh-140px)] p-6">
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							handleSave();
+						}}
+						className="space-y-6"
+					>
+						<FieldGroup className="space-y-4">
+							<Field>
+								<FieldLabel className="font-mono text-xs font-medium tracking-wide mb-0.5">
+									Key Name
+								</FieldLabel>
+								<Input
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									className="h-8 font-mono focus:border-purple-500 focus:ring-purple-500/20 text-sm"
+									placeholder="My Integration"
+									autoFocus
+								/>
+							</Field>
+						</FieldGroup>
+
+						{/* Action Buttons */}
+						<div className="flex gap-4 pt-2">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={handleCancel}
+								className="font-mono h-8 text-sm"
+								disabled={isSaving}
+							>
+								Cancel
+							</Button>
+							<GlowButton
+								type="submit"
+								glowColor={glowColors.blue}
+								disabled={isSaving || !name.trim()}
+								className="flex-1 font-mono h-8 text-sm"
+							>
+								{isSaving ? "Saving..." : "Save Changes"}
+							</GlowButton>
+						</div>
+					</form>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,7 @@
 import { passkeyClient } from "@better-auth/passkey/client";
-import { organizationClient } from "better-auth/client/plugins";
+import { apiKeyClient, organizationClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
-	plugins: [organizationClient({}), passkeyClient()],
+	plugins: [organizationClient({}), passkeyClient(), apiKeyClient()],
 });

--- a/apps/web/src/routes/_authenticated/_sidebar/profile.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/profile.tsx
@@ -11,6 +11,8 @@ import {
 	Target01Icon,
 	SecurityLockIcon,
 	Alert02Icon,
+	Copy01Icon,
+	Add01Icon,
 } from "@hugeicons/core-free-icons";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -34,6 +36,8 @@ import { Header } from "@/components/layout/header";
 import { authClient } from "@/lib/auth-client";
 import { EditProfileDialog } from "@/components/profile/edit-profile-dialog";
 import { EditPasskeyDialog } from "@/components/profile/edit-passkey-dialog";
+import { CreateApiKeyDialog } from "@/components/devices/create-api-key-dialog";
+import { EditApiKeyDialog } from "@/components/devices/edit-api-key-dialog";
 import { useSession, fetchSessionForRoute } from "@/hooks/useSession";
 import { useSignOut } from "@/hooks/useSignOut";
 import { useTRPC } from "@/lib/trpc";
@@ -66,6 +70,9 @@ function ProfilePage() {
 	const [editingPasskey, setEditingPasskey] = useState<{ id: string; name: string } | null>(null);
 	const [isRevokeOtherDialogOpen, setIsRevokeOtherDialogOpen] = useState(false);
 	const [isRevokeAllDialogOpen, setIsRevokeAllDialogOpen] = useState(false);
+	const [isCreateApiKeyOpen, setIsCreateApiKeyOpen] = useState(false);
+	const [editingApiKey, setEditingApiKey] = useState<{ id: string; name: string } | null>(null);
+	const [newApiKeyValue, setNewApiKeyValue] = useState<string | null>(null);
 	const queryClient = useQueryClient();
 	const trpc = useTRPC();
 
@@ -95,6 +102,18 @@ function ProfilePage() {
 			console.log("Sessions data:", data);
 			if (error) {
 				throw new Error(error.message || "Failed to load sessions");
+			}
+			return data;
+		},
+	});
+
+	// API keys query - using Better Auth's built-in apiKey client
+	const apiKeysQuery = useQuery({
+		queryKey: ["api-keys"],
+		queryFn: async () => {
+			const { data, error } = await authClient.apiKey.list();
+			if (error) {
+				throw new Error(error.message || "Failed to load API keys");
 			}
 			return data;
 		},
@@ -214,6 +233,76 @@ function ProfilePage() {
 			toast.error(err instanceof Error ? err.message : "Failed to revoke all sessions");
 		},
 	});
+
+	// API key mutations - using Better Auth's built-in apiKey client
+	const createApiKeyMutation = useMutation({
+		mutationFn: async (name: string) => {
+			const { data, error } = await authClient.apiKey.create({ name });
+			if (error) {
+				throw new Error(error.message || "Failed to create API key");
+			}
+			return data;
+		},
+		onSuccess: (data) => {
+			toast.success("API key created");
+			setNewApiKeyValue(data.key);
+			setIsCreateApiKeyOpen(false);
+			void queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+		},
+		onError: (err) => {
+			toast.error(err instanceof Error ? err.message : "Failed to create API key");
+		},
+	});
+
+	const updateApiKeyMutation = useMutation({
+		mutationFn: async ({ keyId, name }: { keyId: string; name: string }) => {
+			const { error } = await authClient.apiKey.update({ keyId, name });
+			if (error) {
+				throw new Error(error.message || "Failed to update API key");
+			}
+		},
+		onSuccess: () => {
+			toast.success("API key updated");
+			setEditingApiKey(null);
+			void queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+		},
+		onError: (err) => {
+			toast.error(err instanceof Error ? err.message : "Failed to update API key");
+		},
+	});
+
+	const deleteApiKeyMutation = useMutation({
+		mutationFn: async (keyId: string) => {
+			const { error } = await authClient.apiKey.delete({ keyId });
+			if (error) {
+				throw new Error(error.message || "Failed to delete API key");
+			}
+		},
+		onSuccess: () => {
+			toast.success("API key deleted");
+			void queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+		},
+		onError: (err) => {
+			toast.error(err instanceof Error ? err.message : "Failed to delete API key");
+		},
+	});
+
+	const handleCopyApiKey = async (key: string) => {
+		try {
+			await navigator.clipboard.writeText(key);
+			toast.success("API key copied to clipboard");
+		} catch {
+			toast.error("Failed to copy API key");
+		}
+	};
+
+	const formatApiKeyDate = (date: Date) => {
+		return new Date(date).toLocaleDateString("en-US", {
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		});
+	};
 
 	const getInitials = (name?: string | null) => {
 		if (!name) return "U";
@@ -429,6 +518,108 @@ function ProfilePage() {
 									<HugeiconsIcon icon={Key01Icon} className="size-5" />
 								</div>
 								<p>No passkeys registered yet</p>
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* API Keys Section */}
+				<div className="bg-muted/50 p-6">
+					<div className="space-y-4">
+						<div className="flex items-center justify-between">
+							<h3 className="text-lg font-medium">API Keys</h3>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => setIsCreateApiKeyOpen(true)}
+								className="text-muted-foreground hover:text-blue-500"
+								data-testid="add-api-key-button"
+							>
+								<span className="hidden sm:inline">Add API Key</span>
+								<HugeiconsIcon icon={Add01Icon} className="sm:hidden size-4" />
+							</Button>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							API keys for companion devices like Tallyo to record matches hands-free
+						</p>
+						{apiKeysQuery.isLoading ? (
+							<div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+								Loading API keys...
+							</div>
+						) : apiKeysQuery.error ? (
+							<div className="flex h-32 items-center justify-center text-sm text-destructive">
+								{apiKeysQuery.error instanceof Error
+									? apiKeysQuery.error.message
+									: "Failed to load API keys"}
+							</div>
+						) : apiKeysQuery.data && apiKeysQuery.data.length > 0 ? (
+							<div className="divide-y divide-border border">
+								{apiKeysQuery.data.map((apiKey) => (
+									<RowCard
+										key={apiKey.id}
+										icon={<HugeiconsIcon icon={Key01Icon} className="size-5 text-primary" />}
+										iconClassName="bg-primary/10"
+										title={apiKey.name || "Unnamed Key"}
+										subtitle={
+											<>
+												<span className="font-mono">{apiKey.start}...</span>
+												<span>•</span>
+												<span>Created {formatApiKeyDate(apiKey.createdAt)}</span>
+											</>
+										}
+									>
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={() => {
+												setEditingApiKey({
+													id: apiKey.id,
+													name: apiKey.name || "",
+												});
+											}}
+										>
+											<span className="hidden sm:inline">Edit</span>
+											<span className="sm:hidden">
+												<HugeiconsIcon icon={Edit01Icon} className="size-4" />
+											</span>
+										</Button>
+										<AlertDialog>
+											<AlertDialogTrigger>
+												<Button variant="ghost" size="sm" className="hover:text-red-500">
+													<span className="hidden sm:inline">Delete</span>
+													<span className="sm:hidden">
+														<HugeiconsIcon icon={Delete01Icon} className="size-4" />
+													</span>
+												</Button>
+											</AlertDialogTrigger>
+											<AlertDialogContent>
+												<AlertDialogHeader>
+													<AlertDialogTitle>Delete API Key?</AlertDialogTitle>
+													<AlertDialogDescription>
+														Are you sure you want to delete this API key? Any devices using this key
+														will no longer be able to access the API.
+													</AlertDialogDescription>
+												</AlertDialogHeader>
+												<AlertDialogFooter>
+													<AlertDialogCancel>Cancel</AlertDialogCancel>
+													<AlertDialogAction
+														onClick={() => deleteApiKeyMutation.mutate(apiKey.id)}
+														className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+													>
+														Delete
+													</AlertDialogAction>
+												</AlertDialogFooter>
+											</AlertDialogContent>
+										</AlertDialog>
+									</RowCard>
+								))}
+							</div>
+						) : (
+							<div className="flex h-32 flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+								<div className="flex h-12 w-12 items-center justify-center rounded-full bg-background shadow-sm">
+									<HugeiconsIcon icon={Key01Icon} className="size-5" />
+								</div>
+								<p>No API keys yet</p>
 							</div>
 						)}
 					</div>
@@ -724,6 +915,67 @@ function ProfilePage() {
 					</div>
 				</DialogContent>
 			</Dialog>
+
+			{/* Create API Key Dialog */}
+			<CreateApiKeyDialog
+				isOpen={isCreateApiKeyOpen}
+				onClose={() => setIsCreateApiKeyOpen(false)}
+				onCreate={(name) => createApiKeyMutation.mutate(name)}
+				isCreating={createApiKeyMutation.isPending}
+			/>
+
+			{/* Edit API Key Dialog */}
+			{editingApiKey && (
+				<EditApiKeyDialog
+					isOpen={!!editingApiKey}
+					onClose={() => setEditingApiKey(null)}
+					onSave={(name) => {
+						if (editingApiKey) {
+							updateApiKeyMutation.mutate({ keyId: editingApiKey.id, name });
+						}
+					}}
+					currentName={editingApiKey.name}
+					isSaving={updateApiKeyMutation.isPending}
+				/>
+			)}
+
+			{/* New API Key Display Dialog */}
+			{newApiKeyValue && (
+				<AlertDialog open={!!newApiKeyValue} onOpenChange={() => setNewApiKeyValue(null)}>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>API Key Created</AlertDialogTitle>
+							<AlertDialogDescription className="space-y-4">
+								<p>
+									Copy your API key now. You won't be able to see it again after closing this
+									dialog.
+								</p>
+								<div className="flex items-center gap-2 p-3 bg-muted rounded-lg font-mono text-sm break-all">
+									<code className="flex-1" data-testid="new-api-key-value">
+										{newApiKeyValue}
+									</code>
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => handleCopyApiKey(newApiKeyValue)}
+										className="flex-shrink-0"
+									>
+										<HugeiconsIcon icon={Copy01Icon} className="size-4" />
+									</Button>
+								</div>
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogAction
+								onClick={() => setNewApiKeyValue(null)}
+								data-testid="api-key-done-button"
+							>
+								Done
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			)}
 		</>
 	);
 }

--- a/apps/worker/migrations/0006_20260212193233_wandering_squadron_sinister.sql
+++ b/apps/worker/migrations/0006_20260212193233_wandering_squadron_sinister.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `apikey` (
+	`id` text PRIMARY KEY,
+	`name` text,
+	`start` text,
+	`prefix` text,
+	`key` text NOT NULL,
+	`user_id` text NOT NULL,
+	`refill_interval` integer,
+	`refill_amount` integer,
+	`last_refill_at` integer,
+	`enabled` integer DEFAULT 1 NOT NULL,
+	`rate_limit_enabled` integer DEFAULT 1 NOT NULL,
+	`rate_limit_time_window` integer,
+	`rate_limit_max` integer,
+	`request_count` integer DEFAULT 0 NOT NULL,
+	`remaining` integer,
+	`last_request` integer,
+	`expires_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`permissions` text,
+	`metadata` text,
+	CONSTRAINT `fk_apikey_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `apikey_userId_idx` ON `apikey` (`user_id`);

--- a/apps/worker/migrations/20260212193233_wandering_squadron_sinister/migration.sql
+++ b/apps/worker/migrations/20260212193233_wandering_squadron_sinister/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `apikey` (
+	`id` text PRIMARY KEY,
+	`name` text,
+	`start` text,
+	`prefix` text,
+	`key` text NOT NULL,
+	`user_id` text NOT NULL,
+	`refill_interval` integer,
+	`refill_amount` integer,
+	`last_refill_at` integer,
+	`enabled` integer DEFAULT 1 NOT NULL,
+	`rate_limit_enabled` integer DEFAULT 1 NOT NULL,
+	`rate_limit_time_window` integer,
+	`rate_limit_max` integer,
+	`request_count` integer DEFAULT 0 NOT NULL,
+	`remaining` integer,
+	`last_request` integer,
+	`expires_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`permissions` text,
+	`metadata` text,
+	CONSTRAINT `fk_apikey_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `apikey_userId_idx` ON `apikey` (`user_id`);

--- a/apps/worker/migrations/20260212193233_wandering_squadron_sinister/snapshot.json
+++ b/apps/worker/migrations/20260212193233_wandering_squadron_sinister/snapshot.json
@@ -1,0 +1,3112 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "aee6cfb3-8e99-4e03-ba71-ed381dea03f9",
+	"prevIds": ["17a4fa92-685b-4018-ba77-69cdbbe61b5e"],
+	"ddl": [
+		{
+			"name": "account",
+			"entityType": "tables"
+		},
+		{
+			"name": "apikey",
+			"entityType": "tables"
+		},
+		{
+			"name": "invitation",
+			"entityType": "tables"
+		},
+		{
+			"name": "league",
+			"entityType": "tables"
+		},
+		{
+			"name": "member",
+			"entityType": "tables"
+		},
+		{
+			"name": "passkey",
+			"entityType": "tables"
+		},
+		{
+			"name": "session",
+			"entityType": "tables"
+		},
+		{
+			"name": "user",
+			"entityType": "tables"
+		},
+		{
+			"name": "verification",
+			"entityType": "tables"
+		},
+		{
+			"name": "user_preference",
+			"entityType": "tables"
+		},
+		{
+			"name": "fixture",
+			"entityType": "tables"
+		},
+		{
+			"name": "league_team",
+			"entityType": "tables"
+		},
+		{
+			"name": "league_team_player",
+			"entityType": "tables"
+		},
+		{
+			"name": "match",
+			"entityType": "tables"
+		},
+		{
+			"name": "match_player",
+			"entityType": "tables"
+		},
+		{
+			"name": "match_team",
+			"entityType": "tables"
+		},
+		{
+			"name": "player",
+			"entityType": "tables"
+		},
+		{
+			"name": "player_achievement",
+			"entityType": "tables"
+		},
+		{
+			"name": "season",
+			"entityType": "tables"
+		},
+		{
+			"name": "season_player",
+			"entityType": "tables"
+		},
+		{
+			"name": "season_team",
+			"entityType": "tables"
+		},
+		{
+			"name": "device_api_key",
+			"entityType": "tables"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "provider_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id_token",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "access_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refresh_token_expires_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "scope",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "account"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "start",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "prefix",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refill_interval",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "refill_amount",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_refill_at",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "enabled",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "1",
+			"generated": null,
+			"name": "rate_limit_enabled",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "rate_limit_time_window",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "rate_limit_max",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "request_count",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "remaining",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_request",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "permissions",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "apikey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'pending'",
+			"generated": null,
+			"name": "status",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "inviter_id",
+			"entityType": "columns",
+			"table": "invitation"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "metadata",
+			"entityType": "columns",
+			"table": "league"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "organization_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'member'",
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "member"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "public_key",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "credential_id",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "counter",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "device_type",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "backed_up",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "transports",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "aaguid",
+			"entityType": "columns",
+			"table": "passkey"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "ip_address",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_agent",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "active_organization_id",
+			"entityType": "columns",
+			"table": "session"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "email",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "email_verified",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "image",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "user"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "identifier",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "value",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "verification"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "default_organization_id",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_active_organization_id",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "user_preference"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "round",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "match_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_player_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "away_player_id",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "fixture"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "logo",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "league_team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "player_id",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_team_id",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "league_team_player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_score",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "away_score",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "real",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_expected_elo",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "real",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "away_expected_elo",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_by",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_by",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "match"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_player_id",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "home_team",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "match_id",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_before",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_after",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "result",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "match_player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_team_id",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "match_id",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_before",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "-1",
+			"generated": null,
+			"name": "score_after",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "result",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "match_team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "disabled",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "player_id",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "type",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "player_achievement"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "initial_score",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "score_type",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "k_factor",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "start_date",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "end_date",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "rounds",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "archived",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "closed",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_by",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "updated_by",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "season"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "player_id",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "score",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "disabled",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "season_player"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "season_id",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_team_id",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "score",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "season_team"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key_hash",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "key_prefix",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "league_id",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_by",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_used_at",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "(unixepoch())",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "deleted_at",
+			"entityType": "columns",
+			"table": "device_api_key"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_account_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "account"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_apikey_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "apikey"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_invitation_organization_id_league_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["inviter_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_invitation_inviter_id_user_id_fk",
+			"entityType": "fks",
+			"table": "invitation"
+		},
+		{
+			"columns": ["organization_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_member_organization_id_league_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_member_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "member"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_passkey_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "passkey"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_session_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "session"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_user_preference_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "user_preference"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_fixture_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["match_id"],
+			"tableTo": "match",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "set null",
+			"nameExplicit": false,
+			"name": "fk_fixture_match_id_match_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["home_player_id"],
+			"tableTo": "season_player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_fixture_home_player_id_season_player_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["away_player_id"],
+			"tableTo": "season_player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_fixture_away_player_id_season_player_id_fk",
+			"entityType": "fks",
+			"table": "fixture"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_org_team_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "league_team"
+		},
+		{
+			"columns": ["player_id"],
+			"tableTo": "player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_org_team_player_player_id_player_id_fk",
+			"entityType": "fks",
+			"table": "league_team_player"
+		},
+		{
+			"columns": ["league_team_id"],
+			"tableTo": "league_team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_org_team_player_org_team_id_org_team_id_fk",
+			"entityType": "fks",
+			"table": "league_team_player"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "match"
+		},
+		{
+			"columns": ["season_player_id"],
+			"tableTo": "season_player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_player_season_player_id_season_player_id_fk",
+			"entityType": "fks",
+			"table": "match_player"
+		},
+		{
+			"columns": ["match_id"],
+			"tableTo": "match",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_player_match_id_match_id_fk",
+			"entityType": "fks",
+			"table": "match_player"
+		},
+		{
+			"columns": ["season_team_id"],
+			"tableTo": "season_team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_team_season_team_id_season_team_id_fk",
+			"entityType": "fks",
+			"table": "match_team"
+		},
+		{
+			"columns": ["match_id"],
+			"tableTo": "match",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_match_team_match_id_match_id_fk",
+			"entityType": "fks",
+			"table": "match_team"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_player_user_id_user_id_fk",
+			"entityType": "fks",
+			"table": "player"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_player_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "player"
+		},
+		{
+			"columns": ["player_id"],
+			"tableTo": "player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_player_achievement_player_id_player_id_fk",
+			"entityType": "fks",
+			"table": "player_achievement"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "season"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_player_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "season_player"
+		},
+		{
+			"columns": ["player_id"],
+			"tableTo": "player",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_player_player_id_player_id_fk",
+			"entityType": "fks",
+			"table": "season_player"
+		},
+		{
+			"columns": ["season_id"],
+			"tableTo": "season",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_team_season_id_season_id_fk",
+			"entityType": "fks",
+			"table": "season_team"
+		},
+		{
+			"columns": ["league_team_id"],
+			"tableTo": "league_team",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_season_team_org_team_id_org_team_id_fk",
+			"entityType": "fks",
+			"table": "season_team"
+		},
+		{
+			"columns": ["league_id"],
+			"tableTo": "league",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_device_api_key_league_id_league_id_fk",
+			"entityType": "fks",
+			"table": "device_api_key"
+		},
+		{
+			"columns": ["created_by"],
+			"tableTo": "user",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "cascade",
+			"nameExplicit": false,
+			"name": "fk_device_api_key_created_by_user_id_fk",
+			"entityType": "fks",
+			"table": "device_api_key"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "account_pk",
+			"table": "account",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "apikey_pk",
+			"table": "apikey",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "invitation_pk",
+			"table": "invitation",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "league_pk",
+			"table": "league",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "member_pk",
+			"table": "member",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "passkey_pk",
+			"table": "passkey",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "session_pk",
+			"table": "session",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "user_pk",
+			"table": "user",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "verification_pk",
+			"table": "verification",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["user_id"],
+			"nameExplicit": false,
+			"name": "user_preference_pk",
+			"table": "user_preference",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "fixture_pk",
+			"table": "fixture",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "org_team_pk",
+			"table": "league_team",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "org_team_player_pk",
+			"table": "league_team_player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "match_pk",
+			"table": "match",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "match_player_pk",
+			"table": "match_player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "match_team_pk",
+			"table": "match_team",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "player_pk",
+			"table": "player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "player_achievement_pk",
+			"table": "player_achievement",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "season_pk",
+			"table": "season",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "season_player_pk",
+			"table": "season_player",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "season_team_pk",
+			"table": "season_team",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "device_api_key_pk",
+			"table": "device_api_key",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "account_userId_idx",
+			"entityType": "indexes",
+			"table": "account"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "apikey_userId_idx",
+			"entityType": "indexes",
+			"table": "apikey"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_organizationId_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "email",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "invitation_email_idx",
+			"entityType": "indexes",
+			"table": "invitation"
+		},
+		{
+			"columns": [
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "league_slug_uidx",
+			"entityType": "indexes",
+			"table": "league"
+		},
+		{
+			"columns": [
+				{
+					"value": "organization_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "member_org_user_uidx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "member_userId_idx",
+			"entityType": "indexes",
+			"table": "member"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "passkey_userId_idx",
+			"entityType": "indexes",
+			"table": "passkey"
+		},
+		{
+			"columns": [
+				{
+					"value": "credential_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "passkey_credentialID_idx",
+			"entityType": "indexes",
+			"table": "passkey"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "session_userId_idx",
+			"entityType": "indexes",
+			"table": "session"
+		},
+		{
+			"columns": [
+				{
+					"value": "identifier",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "verification_identifier_idx",
+			"entityType": "indexes",
+			"table": "verification"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "fixture_season_id_idx",
+			"entityType": "indexes",
+			"table": "fixture"
+		},
+		{
+			"columns": [
+				{
+					"value": "match_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "fixture_match_id_idx",
+			"entityType": "indexes",
+			"table": "fixture"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "league_team_league_id_idx",
+			"entityType": "indexes",
+			"table": "league_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_team_id",
+					"isExpression": false
+				},
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "league_team_player_team_player_uidx",
+			"entityType": "indexes",
+			"table": "league_team_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "league_team_player_player_id_idx",
+			"entityType": "indexes",
+			"table": "league_team_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				},
+				{
+					"value": "created_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_season_created_idx",
+			"entityType": "indexes",
+			"table": "match"
+		},
+		{
+			"columns": [
+				{
+					"value": "match_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_player_match_id_idx",
+			"entityType": "indexes",
+			"table": "match_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_player_id",
+					"isExpression": false
+				},
+				{
+					"value": "result",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_player_season_player_result_idx",
+			"entityType": "indexes",
+			"table": "match_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_player_id",
+					"isExpression": false
+				},
+				{
+					"value": "created_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_player_season_player_created_idx",
+			"entityType": "indexes",
+			"table": "match_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_team_season_team_id_idx",
+			"entityType": "indexes",
+			"table": "match_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "match_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_team_match_id_idx",
+			"entityType": "indexes",
+			"table": "match_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "created_at",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "match_team_created_at_idx",
+			"entityType": "indexes",
+			"table": "match_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				},
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "player_organization_user_uidx",
+			"entityType": "indexes",
+			"table": "player"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "player_user_id_idx",
+			"entityType": "indexes",
+			"table": "player"
+		},
+		{
+			"columns": [
+				{
+					"value": "player_id",
+					"isExpression": false
+				},
+				{
+					"value": "type",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "player_achievement_player_type_uidx",
+			"entityType": "indexes",
+			"table": "player_achievement"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				},
+				{
+					"value": "slug",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "season_slug_uidx",
+			"entityType": "indexes",
+			"table": "season"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				},
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "season_player_season_player_uidx",
+			"entityType": "indexes",
+			"table": "season_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "player_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "season_player_player_id_idx",
+			"entityType": "indexes",
+			"table": "season_player"
+		},
+		{
+			"columns": [
+				{
+					"value": "season_id",
+					"isExpression": false
+				},
+				{
+					"value": "league_team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": null,
+			"origin": "manual",
+			"name": "season_team_season_team_uidx",
+			"entityType": "indexes",
+			"table": "season_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_team_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "season_team_league_team_id_idx",
+			"entityType": "indexes",
+			"table": "season_team"
+		},
+		{
+			"columns": [
+				{
+					"value": "league_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "device_api_key_league_id_idx",
+			"entityType": "indexes",
+			"table": "device_api_key"
+		},
+		{
+			"columns": [
+				{
+					"value": "created_by",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "device_api_key_created_by_idx",
+			"entityType": "indexes",
+			"table": "device_api_key"
+		},
+		{
+			"columns": [
+				{
+					"value": "key_hash",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "device_api_key_key_hash_idx",
+			"entityType": "indexes",
+			"table": "device_api_key"
+		},
+		{
+			"columns": ["token"],
+			"nameExplicit": false,
+			"name": "session_token_unique",
+			"entityType": "uniques",
+			"table": "session"
+		},
+		{
+			"columns": ["email"],
+			"nameExplicit": false,
+			"name": "user_email_unique",
+			"entityType": "uniques",
+			"table": "user"
+		}
+	],
+	"renames": []
+}

--- a/apps/worker/src/db/schema/auth-schema.ts
+++ b/apps/worker/src/db/schema/auth-schema.ts
@@ -165,6 +165,41 @@ export const passkey = sqliteTable(
 	]
 );
 
+export const apikey = sqliteTable(
+	"apikey",
+	{
+		id: text("id").primaryKey(),
+		name: text("name"),
+		start: text("start"),
+		prefix: text("prefix"),
+		key: text("key").notNull(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		refillInterval: integer("refill_interval"),
+		refillAmount: integer("refill_amount"),
+		lastRefillAt: integer("last_refill_at", { mode: "timestamp_ms" }),
+		enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+		rateLimitEnabled: integer("rate_limit_enabled", { mode: "boolean" }).default(true).notNull(),
+		rateLimitTimeWindow: integer("rate_limit_time_window"),
+		rateLimitMax: integer("rate_limit_max"),
+		requestCount: integer("request_count").default(0).notNull(),
+		remaining: integer("remaining"),
+		lastRequest: integer("last_request", { mode: "timestamp_ms" }),
+		expiresAt: integer("expires_at", { mode: "timestamp_ms" }),
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+			.notNull(),
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+			.$onUpdate(() => new Date())
+			.notNull(),
+		permissions: text("permissions"),
+		metadata: text("metadata"),
+	},
+	(table) => [index("apikey_userId_idx").on(table.userId)]
+);
+
 /*export const userRelations = relations(user, ({ many }) => ({
 	sessions: many(session),
 	accounts: many(account),

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -7,6 +7,7 @@ import { contextStorage } from "hono/context-storage";
 import { enforceAuthMiddleware } from "./middleware/auth";
 import { contextMiddleware, type HonoEnv } from "./middleware/context";
 import { authRouter } from "./routes/auth-router";
+import { deviceRouter } from "./routes/device-router";
 import { sseRouter } from "./routes/sse-router";
 import userAssetsRouter from "./routes/user-assets-router";
 import { trpcServer } from "./trpc/server";
@@ -15,10 +16,17 @@ const app = new Hono<HonoEnv>()
 	.use("*", contextStorage())
 	.use("*", contextMiddleware)
 	.route("/api/auth", authRouter)
+	.route("/api/device", deviceRouter)
 	.route("/api/sse", sseRouter)
 	.use("/api/user-assets/*", enforceAuthMiddleware)
 	.route("/api/user-assets", userAssetsRouter)
 	.use("/api/trpc/*", trpcServer)
-	.use("*", enforceAuthMiddleware);
+	.use("*", async (c, next) => {
+		// Device routes handle their own auth via API key
+		if (c.req.path.startsWith("/api/device/") || c.req.path.startsWith("/api/device")) {
+			return next();
+		}
+		return enforceAuthMiddleware(c, next);
+	});
 
 export default app;

--- a/apps/worker/src/lib/better-auth.ts
+++ b/apps/worker/src/lib/better-auth.ts
@@ -1,7 +1,7 @@
 import { passkey } from "@better-auth/passkey";
 import { betterAuth } from "better-auth";
 import { type DB, drizzleAdapter } from "better-auth/adapters/drizzle";
-import { organization } from "better-auth/plugins";
+import { organization, apiKey } from "better-auth/plugins";
 import { hashPassword, verifyPassword } from "../lib/password";
 import { createAccessControl } from "better-auth/plugins/access";
 import { afterAcceptInvitation, afterCreateOrganization } from "./better-auth-organization-hooks";
@@ -44,6 +44,7 @@ export function createAuth({
 	googleClientSecret,
 	origin,
 	resendApiKey,
+	isProduction,
 }: {
 	db: DB;
 	betterAuthSecret: string;
@@ -53,6 +54,7 @@ export function createAuth({
 	googleClientSecret?: string;
 	origin?: string;
 	resendApiKey?: string;
+	isProduction?: boolean;
 }) {
 	const hasAnySocialProviders =
 		(githubClientId && githubClientSecret) || (googleClientId && googleClientSecret);
@@ -214,6 +216,10 @@ export function createAuth({
 				rpID,
 				rpName: "Scorebrawl",
 				origin: passkeyOrigin,
+			}),
+			apiKey({
+				defaultPrefix: isProduction ? "sb_live" : "sb_dev",
+				enableMetadata: true,
 			}),
 		],
 	});

--- a/apps/worker/src/routes/device-router.ts
+++ b/apps/worker/src/routes/device-router.ts
@@ -1,0 +1,306 @@
+import { zValidator } from "@hono/zod-validator";
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+import { league, member, player, season, seasonPlayer, user } from "../db/schema";
+import type { EnforcedAuthHonoEnv } from "../middleware/auth";
+import { create as createMatch } from "../repositories/match-repository";
+import type { AuthType } from "../middleware/context";
+
+/**
+ * Device router - endpoints called by Tallyo devices using API key authentication.
+ * Keys are user-scoped, so devices can access any league the user is a member of.
+ * Key management is handled by Better Auth's built-in API key endpoints.
+ */
+const deviceRouter = new Hono<EnforcedAuthHonoEnv>()
+	.use("*", async (c, next) => {
+		const betterAuth = c.get("betterAuth");
+		const db = c.get("db");
+		const apiKey = c.req.header("x-api-key");
+
+		if (!apiKey) {
+			throw new HTTPException(401, { message: "Missing API key" });
+		}
+
+		const result = await betterAuth.api.verifyApiKey({
+			body: { key: apiKey },
+		});
+
+		if (!result.valid || !result.key) {
+			throw new HTTPException(401, { message: "Invalid API key" });
+		}
+
+		const userData = await db.select().from(user).where(eq(user.id, result.key.userId)).get();
+
+		if (!userData) {
+			throw new HTTPException(401, { message: "User not found" });
+		}
+
+		c.set("authentication", {
+			user: userData,
+			session: {
+				id: result.key.id,
+				token: apiKey,
+				userId: result.key.userId,
+				expiresAt: result.key.expiresAt ?? new Date(Date.now() + 86400000),
+				createdAt: result.key.createdAt,
+				updatedAt: result.key.updatedAt,
+				ipAddress: null,
+				userAgent: c.req.header("user-agent") ?? null,
+			},
+		} as AuthType);
+
+		await next();
+	})
+	.get("/leagues", async (c) => {
+		const db = c.get("db");
+		const userId = c.get("authentication").user.id;
+
+		const userLeagues = await db
+			.select({
+				id: league.id,
+				name: league.name,
+				slug: league.slug,
+				logo: league.logo,
+			})
+			.from(member)
+			.innerJoin(league, eq(member.organizationId, league.id))
+			.where(eq(member.userId, userId));
+
+		return c.json({ leagues: userLeagues });
+	})
+	.get("/leagues/:leagueSlug/context", async (c) => {
+		const db = c.get("db");
+		const userId = c.get("authentication").user.id;
+		const { leagueSlug } = c.req.param();
+
+		// Verify user is a member of this league
+		const leagueData = await db
+			.select({ id: league.id, name: league.name, slug: league.slug })
+			.from(league)
+			.where(eq(league.slug, leagueSlug))
+			.get();
+
+		if (!leagueData) {
+			return c.json({ error: "League not found" }, 404);
+		}
+
+		const memberData = await db
+			.select({ id: member.id })
+			.from(member)
+			.where(and(eq(member.organizationId, leagueData.id), eq(member.userId, userId)))
+			.get();
+
+		if (!memberData) {
+			return c.json({ error: "Not a member of this league" }, 403);
+		}
+
+		const seasons = await db
+			.select({
+				id: season.id,
+				name: season.name,
+				slug: season.slug,
+				closed: season.closed,
+				archived: season.archived,
+			})
+			.from(season)
+			.where(and(eq(season.leagueId, leagueData.id), eq(season.archived, false)));
+
+		const activeSeason = seasons.find((s) => !s.closed) || seasons[0];
+
+		if (!activeSeason) {
+			return c.json({
+				league: {
+					id: leagueData.id,
+					name: leagueData.name,
+					slug: leagueData.slug,
+				},
+				season: null,
+				players: [],
+			});
+		}
+
+		const players = await db
+			.select({
+				id: seasonPlayer.id,
+				name: user.name,
+				score: seasonPlayer.score,
+			})
+			.from(seasonPlayer)
+			.innerJoin(player, eq(seasonPlayer.playerId, player.id))
+			.innerJoin(user, eq(player.userId, user.id))
+			.where(and(eq(seasonPlayer.seasonId, activeSeason.id), eq(seasonPlayer.disabled, false)));
+
+		return c.json({
+			league: {
+				id: leagueData.id,
+				name: leagueData.name,
+				slug: leagueData.slug,
+			},
+			season: {
+				id: activeSeason.id,
+				name: activeSeason.name,
+				slug: activeSeason.slug,
+			},
+			players: players.map((p) => ({
+				id: p.id,
+				name: p.name,
+				score: p.score,
+			})),
+		});
+	});
+
+const createMatchSchema = z.object({
+	seasonSlug: z.string().min(1),
+	homePlayerNames: z.array(z.string()).min(1),
+	awayPlayerNames: z.array(z.string()).min(1),
+	homeScore: z.number().int().min(0),
+	awayScore: z.number().int().min(0),
+});
+
+deviceRouter.post(
+	"/leagues/:leagueSlug/matches",
+	zValidator("json", createMatchSchema),
+	async (c) => {
+		const db = c.get("db");
+		const userId = c.get("authentication").user.id;
+		const { leagueSlug } = c.req.param();
+
+		// Verify user is a member of this league
+		const leagueData = await db
+			.select({ id: league.id })
+			.from(league)
+			.where(eq(league.slug, leagueSlug))
+			.get();
+
+		if (!leagueData) {
+			return c.json({ error: "League not found" }, 404);
+		}
+
+		const memberData = await db
+			.select({ id: member.id })
+			.from(member)
+			.where(and(eq(member.organizationId, leagueData.id), eq(member.userId, userId)))
+			.get();
+
+		if (!memberData) {
+			return c.json({ error: "Not a member of this league" }, 403);
+		}
+
+		const { seasonSlug, homePlayerNames, awayPlayerNames, homeScore, awayScore } =
+			c.req.valid("json");
+
+		const seasonData = await db
+			.select({ id: season.id, closed: season.closed })
+			.from(season)
+			.where(and(eq(season.leagueId, leagueData.id), eq(season.slug, seasonSlug)))
+			.get();
+
+		if (!seasonData) {
+			return c.json({ error: "Season not found" }, 404);
+		}
+
+		if (seasonData.closed) {
+			return c.json({ error: "Season is closed" }, 400);
+		}
+
+		// Get all active players in the season for name matching
+		const players = await db
+			.select({
+				id: seasonPlayer.id,
+				name: user.name,
+			})
+			.from(seasonPlayer)
+			.innerJoin(player, eq(seasonPlayer.playerId, player.id))
+			.innerJoin(user, eq(player.userId, user.id))
+			.where(and(eq(seasonPlayer.seasonId, seasonData.id), eq(seasonPlayer.disabled, false)));
+
+		// Match player names to season player IDs (voice input may be fuzzy)
+		const matchPlayersByName = (names: string[]) => {
+			const matched: { id: string; name: string; originalName: string }[] = [];
+			const unmatched: string[] = [];
+
+			for (const name of names) {
+				const normalizedInput = name.toLowerCase().trim();
+				const exactMatch = players.find((p) => p.name.toLowerCase() === normalizedInput);
+
+				if (exactMatch) {
+					matched.push({ id: exactMatch.id, name: exactMatch.name, originalName: name });
+					continue;
+				}
+
+				const partialMatches = players.filter((p) => {
+					const playerNameLower = p.name.toLowerCase();
+					const firstName = playerNameLower.split(" ")[0];
+					return (
+						playerNameLower.includes(normalizedInput) ||
+						firstName === normalizedInput ||
+						normalizedInput.includes(firstName)
+					);
+				});
+
+				if (partialMatches.length === 1) {
+					matched.push({
+						id: partialMatches[0].id,
+						name: partialMatches[0].name,
+						originalName: name,
+					});
+				} else {
+					unmatched.push(name);
+				}
+			}
+
+			return { matched, unmatched };
+		};
+
+		const homeResult = matchPlayersByName(homePlayerNames);
+		const awayResult = matchPlayersByName(awayPlayerNames);
+
+		const allUnmatched = [...homeResult.unmatched, ...awayResult.unmatched];
+		if (allUnmatched.length > 0) {
+			return c.json(
+				{
+					error: "Could not match players",
+					unmatchedPlayers: allUnmatched,
+					availablePlayers: players.map((p) => p.name),
+				},
+				400
+			);
+		}
+
+		const homeTeamPlayerIds = homeResult.matched.map((p) => p.id);
+		const awayTeamPlayerIds = awayResult.matched.map((p) => p.id);
+
+		if (homeTeamPlayerIds.length !== awayTeamPlayerIds.length) {
+			return c.json({ error: "Teams must have equal number of players" }, 400);
+		}
+
+		// Uses shared match-repository.create - same logic as tRPC match.create
+		const match = await createMatch({
+			db,
+			input: {
+				seasonId: seasonData.id,
+				homeScore,
+				awayScore,
+				homeTeamPlayerIds,
+				awayTeamPlayerIds,
+				userId,
+			},
+		});
+
+		return c.json({
+			success: true,
+			match: {
+				id: match.id,
+				homeScore,
+				awayScore,
+				homePlayers: homeResult.matched.map((p) => p.name),
+				awayPlayers: awayResult.matched.map((p) => p.name),
+				createdAt: match.createdAt.toISOString(),
+			},
+		});
+	}
+);
+
+export { deviceRouter };

--- a/apps/worker/test/device/device-api.spec.ts
+++ b/apps/worker/test/device/device-api.spec.ts
@@ -1,0 +1,378 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { createAuthContext } from "../setup/auth-context-util";
+import { createPlayers } from "../setup/season-context-util";
+import { createTRPCTestClient } from "../trpc/trpc-test-client";
+
+interface PlayerData {
+	id: string;
+	name: string;
+}
+
+async function setupPlayersAndSeason(
+	ctx: Awaited<ReturnType<typeof createAuthContext>>,
+	playerCount: number,
+	seasonOptions: { closed?: boolean } = {}
+) {
+	const client = createTRPCTestClient({ sessionToken: ctx.sessionToken });
+
+	// Create players using the helper
+	await createPlayers(ctx, playerCount);
+
+	const season = await client.season.create.mutate({
+		name: "Test Season",
+		initialScore: 1000,
+		scoreType: "elo",
+		kFactor: 32,
+		startDate: new Date(),
+	});
+
+	if (seasonOptions.closed) {
+		await client.season.updateClosedStatus.mutate({ seasonSlug: season.slug, closed: true });
+	}
+
+	const seasonPlayers = await client.seasonPlayer.getAll.query({
+		seasonSlug: season.slug,
+	});
+
+	return {
+		season,
+		players: seasonPlayers.map((sp) => ({
+			id: sp.id,
+			name: sp.name,
+		})) as PlayerData[],
+	};
+}
+
+// Create API key using Better Auth's built-in endpoint
+async function createApiKey(sessionToken: string, name = "Test Device") {
+	const response = await SELF.fetch("http://localhost/api/auth/api-key/create", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Cookie: `better-auth.session_token=${sessionToken}`,
+			Origin: "http://localhost",
+		},
+		body: JSON.stringify({ name }),
+	});
+	return response;
+}
+
+describe("device API", () => {
+	describe("Better Auth API Key endpoints", () => {
+		it("creates an API key via /api/auth/api-key/create", async () => {
+			const ctx = await createAuthContext();
+
+			const response = await createApiKey(ctx.sessionToken);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as {
+				id: string;
+				name: string;
+				key: string;
+				start: string;
+			};
+			expect(data.id).toBeDefined();
+			expect(data.name).toBe("Test Device");
+			expect(data.key).toMatch(/^sb_dev/);
+			expect(data.start).toBeDefined();
+		});
+
+		it("lists API keys via /api/auth/api-key/list", async () => {
+			const ctx = await createAuthContext();
+			await createApiKey(ctx.sessionToken, "Device 1");
+			await createApiKey(ctx.sessionToken, "Device 2");
+
+			const response = await SELF.fetch("http://localhost/api/auth/api-key/list", {
+				headers: {
+					Cookie: `better-auth.session_token=${ctx.sessionToken}`,
+				},
+			});
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as Array<{ id: string; name: string }>;
+			expect(data.length).toBe(2);
+		});
+	});
+
+	describe("GET /api/device/leagues", () => {
+		it("lists user leagues with valid API key", async () => {
+			const ctx = await createAuthContext();
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch("http://localhost/api/device/leagues", {
+				headers: { "x-api-key": keyData.key },
+			});
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as { leagues: { slug: string }[] };
+			expect(data.leagues).toBeInstanceOf(Array);
+			expect(data.leagues.length).toBeGreaterThan(0);
+			expect(data.leagues.some((l) => l.slug === ctx.league.slug)).toBe(true);
+		});
+
+		it("returns 401 without API key", async () => {
+			const response = await SELF.fetch("http://localhost/api/device/leagues");
+
+			expect(response.status).toBe(401);
+		});
+
+		it("returns 401 with invalid API key", async () => {
+			const response = await SELF.fetch("http://localhost/api/device/leagues", {
+				headers: {
+					"x-api-key":
+						"sb_dev_invalid_key_here_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			});
+
+			expect(response.status).toBe(401);
+		});
+	});
+
+	describe("GET /api/device/leagues/:slug/context", () => {
+		it("returns league context with players", async () => {
+			const ctx = await createAuthContext();
+			const { season } = await setupPlayersAndSeason(ctx, 3);
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${ctx.league.slug}/context`,
+				{
+					headers: { "x-api-key": keyData.key },
+				}
+			);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as {
+				league: { id: string; name: string; slug: string };
+				season: { id: string; name: string; slug: string } | null;
+				players: { id: string; name: string; score: number }[];
+			};
+			expect(data.league.slug).toBe(ctx.league.slug);
+			expect(data.season).not.toBeNull();
+			expect(data.season?.slug).toBe(season.slug);
+			expect(data.players.length).toBe(3);
+		});
+
+		it("returns 403 for league user is not member of", async () => {
+			const ctx = await createAuthContext();
+			const otherCtx = await createAuthContext();
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			// Try to access the other user's league
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${otherCtx.league.slug}/context`,
+				{
+					headers: { "x-api-key": keyData.key },
+				}
+			);
+
+			expect(response.status).toBe(403);
+		});
+	});
+
+	describe("POST /api/device/leagues/:slug/matches", () => {
+		it("creates a match with player names", async () => {
+			const ctx = await createAuthContext();
+			const { season, players } = await setupPlayersAndSeason(ctx, 2);
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${ctx.league.slug}/matches`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": keyData.key,
+					},
+					body: JSON.stringify({
+						seasonSlug: season.slug,
+						homePlayerNames: [players[0].name],
+						awayPlayerNames: [players[1].name],
+						homeScore: 3,
+						awayScore: 1,
+					}),
+				}
+			);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as {
+				success: boolean;
+				match: { id: string; homeScore: number; awayScore: number };
+			};
+			expect(data.success).toBe(true);
+			expect(data.match.homeScore).toBe(3);
+			expect(data.match.awayScore).toBe(1);
+		});
+
+		it("matches players by first name", async () => {
+			const ctx = await createAuthContext();
+			const { season, players } = await setupPlayersAndSeason(ctx, 2);
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const firstName0 = players[0].name.split(" ")[0];
+			const firstName1 = players[1].name.split(" ")[0];
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${ctx.league.slug}/matches`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": keyData.key,
+					},
+					body: JSON.stringify({
+						seasonSlug: season.slug,
+						homePlayerNames: [firstName0],
+						awayPlayerNames: [firstName1],
+						homeScore: 2,
+						awayScore: 0,
+					}),
+				}
+			);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as { success: boolean };
+			expect(data.success).toBe(true);
+		});
+
+		it("returns error for unmatched players", async () => {
+			const ctx = await createAuthContext();
+			const { season } = await setupPlayersAndSeason(ctx, 2);
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${ctx.league.slug}/matches`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": keyData.key,
+					},
+					body: JSON.stringify({
+						seasonSlug: season.slug,
+						homePlayerNames: ["NonExistentPlayer"],
+						awayPlayerNames: ["AnotherFakeName"],
+						homeScore: 1,
+						awayScore: 0,
+					}),
+				}
+			);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as {
+				error: string;
+				unmatchedPlayers: string[];
+				availablePlayers: string[];
+			};
+			expect(data.error).toBe("Could not match players");
+			expect(data.unmatchedPlayers).toContain("NonExistentPlayer");
+			expect(data.availablePlayers).toBeInstanceOf(Array);
+		});
+
+		it("creates 2v2 match", async () => {
+			const ctx = await createAuthContext();
+			const { season, players } = await setupPlayersAndSeason(ctx, 4);
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${ctx.league.slug}/matches`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": keyData.key,
+					},
+					body: JSON.stringify({
+						seasonSlug: season.slug,
+						homePlayerNames: [players[0].name, players[1].name],
+						awayPlayerNames: [players[2].name, players[3].name],
+						homeScore: 5,
+						awayScore: 3,
+					}),
+				}
+			);
+
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as {
+				success: boolean;
+				match: { homePlayers: string[]; awayPlayers: string[] };
+			};
+			expect(data.success).toBe(true);
+			expect(data.match.homePlayers.length).toBe(2);
+			expect(data.match.awayPlayers.length).toBe(2);
+		});
+
+		it("returns error for closed season", async () => {
+			const ctx = await createAuthContext();
+			const { season, players } = await setupPlayersAndSeason(ctx, 2, { closed: true });
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${ctx.league.slug}/matches`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": keyData.key,
+					},
+					body: JSON.stringify({
+						seasonSlug: season.slug,
+						homePlayerNames: [players[0].name],
+						awayPlayerNames: [players[1].name],
+						homeScore: 1,
+						awayScore: 0,
+					}),
+				}
+			);
+
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as { error: string };
+			expect(data.error).toBe("Season is closed");
+		});
+
+		it("returns 403 for league user is not member of", async () => {
+			const ctx = await createAuthContext();
+			const otherCtx = await createAuthContext();
+			const { season, players } = await setupPlayersAndSeason(otherCtx, 2);
+
+			const keyResponse = await createApiKey(ctx.sessionToken);
+			const keyData = (await keyResponse.json()) as { key: string };
+
+			const response = await SELF.fetch(
+				`http://localhost/api/device/leagues/${otherCtx.league.slug}/matches`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": keyData.key,
+					},
+					body: JSON.stringify({
+						seasonSlug: season.slug,
+						homePlayerNames: [players[0].name],
+						awayPlayerNames: [players[1].name],
+						homeScore: 1,
+						awayScore: 0,
+					}),
+				}
+			);
+
+			expect(response.status).toBe(403);
+		});
+	});
+});


### PR DESCRIPTION
- Add Better Auth apiKey plugin for user-scoped API key management
- Add Device API endpoints for companion hardware (Tallyo)
- Add API Keys section on profile page for key CRUD operations
- Environment-based key prefix (sb_live/sb_dev) for production vs dev