### PR TITLE
fix: remove worker from both queues before deletion

### DIFF
--- a/.github/scripts/preview/delete-d1-db.ts
+++ b/.github/scripts/preview/delete-d1-db.ts
@@ -1,28 +1,25 @@
 #!/usr/bin/env bun
+/**
+ * CI script: Delete D1 database
+ * Used by the preview cleanup workflow
+ */
 
-import { $ } from "bun";
+import { deleteDatabase, getResourceNames } from "../../../scripts/lib/cleanup.ts";
 
 const prNumber = process.env.PR_NUMBER;
+
 if (!prNumber) {
 	console.error("PR_NUMBER environment variable is required");
 	process.exit(1);
 }
 
-const dbName = `scorebrawl-db-pr-${prNumber}`;
+const names = getResourceNames(prNumber);
 
-// Check if database exists
 try {
-	const listResult = await $`bun wrangler d1 list --json`.quiet();
-	const databases = JSON.parse(listResult.stdout.toString());
-	const dbExists = databases.find((db: { name: string }) => db.name === dbName);
-
-	if (dbExists) {
-		console.log(`Deleting database: ${dbName}`);
-		await $`bun wrangler d1 delete ${dbName} --skip-confirmation`.quiet();
-	} else {
-		console.log(`Database not found: ${dbName}`);
-	}
+	const result = await deleteDatabase(names.dbName);
+	console.log(`${result.step}: ${result.status === "success" ? "Deleted" : result.message}`);
 } catch {
-	console.log("Failed to list databases, assuming database doesn't exist");
-	process.exit(0);
+	console.log("Failed to delete database, assuming it doesn't exist");
 }
+
+process.exit(0);

--- a/.github/scripts/preview/delete-queue.ts
+++ b/.github/scripts/preview/delete-queue.ts
@@ -1,48 +1,28 @@
 #!/usr/bin/env bun
+/**
+ * CI script: Delete queues
+ * Used by the preview cleanup workflow
+ */
 
-import { $ } from "bun";
-import { Cloudflare } from "cloudflare";
+import { deleteQueue, getResourceNames } from "../../../scripts/lib/cleanup.ts";
 
 const prNumber = process.env.PR_NUMBER;
-const apiToken = process.env.CLOUDFLARE_API_TOKEN;
-const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 
 if (!prNumber) {
 	console.error("PR_NUMBER environment variable is required");
 	process.exit(1);
 }
 
-if (!apiToken || !accountId) {
-	console.error("CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required");
-	process.exit(1);
-}
-
-const achievementQueueName = `scorebrawl-achievement-calculations-pr-${prNumber}`;
-const seedQueueName = `scorebrawl-seed-queue-pr-${prNumber}`;
-
-const cloudflare = new Cloudflare({ apiToken });
-
-async function deleteQueue(queueName: string): Promise<void> {
-	let queueExists = false;
-	for await (const queue of cloudflare.queues.list({ account_id: accountId! })) {
-		if (queue.queue_name === queueName) {
-			queueExists = true;
-			break;
-		}
-	}
-
-	if (queueExists) {
-		console.log(`Deleting queue: ${queueName}`);
-		await $`bun wrangler queues delete ${queueName}`.quiet();
-	} else {
-		console.log(`Queue not found: ${queueName}`);
-	}
-}
+const names = getResourceNames(prNumber);
 
 try {
-	await deleteQueue(achievementQueueName);
-	await deleteQueue(seedQueueName);
+	const result1 = await deleteQueue(names.achievementQueueName);
+	console.log(`${result1.step}: ${result1.status === "success" ? "Deleted" : result1.message}`);
+
+	const result2 = await deleteQueue(names.seedQueueName);
+	console.log(`${result2.step}: ${result2.status === "success" ? "Deleted" : result1.message}`);
 } catch {
-	console.log("Failed to list/delete queues, assuming they don't exist");
-	process.exit(0);
+	console.log("Failed to delete queues, assuming they don't exist");
 }
+
+process.exit(0);

--- a/.github/scripts/preview/delete-queue.ts
+++ b/.github/scripts/preview/delete-queue.ts
@@ -20,7 +20,7 @@ try {
 	console.log(`${result1.step}: ${result1.status === "success" ? "Deleted" : result1.message}`);
 
 	const result2 = await deleteQueue(names.seedQueueName);
-	console.log(`${result2.step}: ${result2.status === "success" ? "Deleted" : result1.message}`);
+	console.log(`${result2.step}: ${result2.status === "success" ? "Deleted" : result2.message}`);
 } catch {
 	console.log("Failed to delete queues, assuming they don't exist");
 }

--- a/.github/scripts/preview/delete-r2-bucket.ts
+++ b/.github/scripts/preview/delete-r2-bucket.ts
@@ -1,65 +1,26 @@
 #!/usr/bin/env bun
+/**
+ * CI script: Delete R2 bucket
+ * Used by the preview cleanup workflow
+ */
 
-import { $ } from "bun";
-import { Cloudflare } from "cloudflare";
+import { deleteR2Bucket, getResourceNames } from "../../../scripts/lib/cleanup.ts";
 
 const prNumber = process.env.PR_NUMBER;
-const apiToken = process.env.CLOUDFLARE_API_TOKEN;
-const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 
 if (!prNumber) {
 	console.error("PR_NUMBER environment variable is required");
 	process.exit(1);
 }
 
-if (!apiToken || !accountId) {
-	console.error("CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required");
-	process.exit(1);
-}
+const names = getResourceNames(prNumber);
 
-const buckets = [`scorebrawl-user-assets-pr-${prNumber}`];
-
-// Check if buckets exist using Cloudflare SDK
 try {
-	const cloudflare = new Cloudflare({
-		apiToken,
-	});
-
-	const existingBucketsList = await cloudflare.r2.buckets.list({
-		account_id: accountId,
-	});
-
-	const existingBuckets = new Set(existingBucketsList.buckets?.map((bucket) => bucket.name) ?? []);
-
-	for (const bucketName of buckets) {
-		if (existingBuckets.has(bucketName)) {
-			console.log(`Processing R2 bucket: ${bucketName}`);
-
-			try {
-				// First, remove all objects from the bucket using Wrangler CLI
-				console.log(`Removing all objects from bucket: ${bucketName}`);
-
-				// Use Wrangler to delete all objects in the bucket
-				try {
-					await $`bun wrangler r2 object delete --bucket ${bucketName} --prefix ""`.quiet();
-					console.log(`Removed all objects from bucket: ${bucketName}`);
-				} catch {
-					// If the bucket is empty or the delete fails, continue with bucket deletion
-					console.log(`No objects found or failed to delete objects from bucket: ${bucketName}`);
-				}
-
-				// Now delete the empty bucket using Wrangler CLI
-				console.log(`Deleting R2 bucket: ${bucketName}`);
-				await $`bun wrangler r2 bucket delete ${bucketName}`.quiet();
-				console.log(`Successfully deleted bucket: ${bucketName}`);
-			} catch (error) {
-				console.error(`Failed to delete R2 bucket ${bucketName}:`, error);
-			}
-		} else {
-			console.log(`R2 bucket not found: ${bucketName}`);
-		}
-	}
+	const result = await deleteR2Bucket(names.bucketName);
+	console.log(`${result.step}: ${result.status === "success" ? "Deleted" : result.message}`);
 } catch (error) {
-	console.error("Failed to list/delete buckets:", error);
+	console.error("Failed to delete R2 bucket:", error);
 	process.exit(1);
 }
+
+process.exit(0);

--- a/.github/scripts/preview/remove-queue-consumer.ts
+++ b/.github/scripts/preview/remove-queue-consumer.ts
@@ -1,51 +1,36 @@
 #!/usr/bin/env bun
+/**
+ * CI script: Remove worker as queue consumer
+ * Used by the preview cleanup workflow
+ */
 
-import { $ } from "bun";
-import { Cloudflare } from "cloudflare";
+import {
+	removeQueueConsumer,
+	getResourceNames,
+	validateSafetyCheck,
+} from "../../../scripts/lib/cleanup.ts";
 
 const prNumber = process.env.PR_NUMBER;
-const apiToken = process.env.CLOUDFLARE_API_TOKEN;
-const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 
 if (!prNumber) {
 	console.error("PR_NUMBER environment variable is required");
 	process.exit(1);
 }
 
-if (!apiToken || !accountId) {
-	console.error("CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required");
-	process.exit(1);
-}
+const names = getResourceNames(prNumber);
 
-const achievementQueueName = `scorebrawl-achievement-calculations-pr-${prNumber}`;
-const seedQueueName = `scorebrawl-seed-queue-pr-${prNumber}`;
-const workerName = `scorebrawl-pr-${prNumber}`;
-
-async function removeConsumer(queueName: string): Promise<void> {
-	const cloudflare = new Cloudflare({ apiToken });
-
-	// Check if queue exists
-	let queueExists = false;
-	for await (const queue of cloudflare.queues.list({ account_id: accountId })) {
-		if (queue.queue_name === queueName) {
-			queueExists = true;
-			break;
-		}
-	}
-
-	if (queueExists) {
-		console.log(`Removing ${workerName} as consumer from queue: ${queueName}`);
-		await $`bun wrangler queues consumer remove ${queueName} ${workerName}`.quiet();
-		console.log(`Removed ${workerName} as consumer from queue ${queueName}`);
-	} else {
-		console.log(`Queue not found: ${queueName}`);
-	}
-}
+// Safety check
+validateSafetyCheck(names.workerName);
 
 try {
-	await removeConsumer(achievementQueueName);
-	await removeConsumer(seedQueueName);
+	// Remove from both queues
+	const result1 = await removeQueueConsumer(names.achievementQueueName, names.workerName);
+	console.log(`${result1.step}: ${result1.status === "success" ? "Removed" : result1.message}`);
+
+	const result2 = await removeQueueConsumer(names.seedQueueName, names.workerName);
+	console.log(`${result2.step}: ${result2.status === "success" ? "Removed" : result2.message}`);
 } catch (error) {
-	console.log("Failed to remove queue consumer:", error);
-	process.exit(0);
+	console.log("Error removing queue consumer (continuing):", error);
 }
+
+process.exit(0);

--- a/.github/scripts/preview/remove-queue-consumer.ts
+++ b/.github/scripts/preview/remove-queue-consumer.ts
@@ -17,10 +17,11 @@ if (!apiToken || !accountId) {
 	process.exit(1);
 }
 
-const queueName = `scorebrawl-achievement-calculations-pr-${prNumber}`;
+const achievementQueueName = `scorebrawl-achievement-calculations-pr-${prNumber}`;
+const seedQueueName = `scorebrawl-seed-queue-pr-${prNumber}`;
 const workerName = `scorebrawl-pr-${prNumber}`;
 
-try {
+async function removeConsumer(queueName: string): Promise<void> {
 	const cloudflare = new Cloudflare({ apiToken });
 
 	// Check if queue exists
@@ -39,6 +40,11 @@ try {
 	} else {
 		console.log(`Queue not found: ${queueName}`);
 	}
+}
+
+try {
+	await removeConsumer(achievementQueueName);
+	await removeConsumer(seedQueueName);
 } catch (error) {
 	console.log("Failed to remove queue consumer:", error);
 	process.exit(0);

--- a/scripts/cleanup-preview-env.ts
+++ b/scripts/cleanup-preview-env.ts
@@ -37,7 +37,9 @@ const prNumber = prNumberArg;
 console.log(`🧹 Cleaning up preview environment for PR #${prNumber}`);
 console.log(`   Worker: scorebrawl-pr-${prNumber}`);
 console.log(`   Database: scorebrawl-db-pr-${prNumber}`);
-console.log(`   Queues: scorebrawl-achievement-calculations-pr-${prNumber}, scorebrawl-seed-queue-pr-${prNumber}`);
+console.log(
+	`   Queues: scorebrawl-achievement-calculations-pr-${prNumber}, scorebrawl-seed-queue-pr-${prNumber}`
+);
 console.log(`   R2 Bucket: scorebrawl-user-assets-pr-${prNumber}`);
 console.log("");
 

--- a/scripts/cleanup-preview-env.ts
+++ b/scripts/cleanup-preview-env.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S bun run
+/**
+ * Manual cleanup script for preview environments
+ * Usage: ./scripts/cleanup-preview-env.ts [OPTIONS] <PR_NUMBER>
+ *
+ * Options:
+ *   --debug    Show verbose output from all commands
+ *
+ * Works with local wrangler authentication (OAuth) - no env vars needed!
+ * Or with env vars for CI: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+ *
+ * SAFETY: This script will NEVER delete the main "scorebrawl" worker.
+ * It only works with preview environments matching pattern: scorebrawl-pr-{N}
+ */
+
+import { runCleanup, type CleanupResult } from "./lib/cleanup.ts";
+
+const args = process.argv.slice(2);
+const debug = args.includes("--debug");
+const prNumberArg = args.find((arg) => /^\d+$/.test(arg));
+
+// Validate PR number
+if (!prNumberArg) {
+	console.error("❌ Error: PR number is required as an argument");
+	console.error("Usage: ./scripts/cleanup-preview-env.ts [OPTIONS] <PR_NUMBER>");
+	console.error("Options:");
+	console.error("  --debug    Show verbose output from all commands");
+	console.error("");
+	console.error("Examples:");
+	console.error("  ./scripts/cleanup-preview-env.ts 634");
+	console.error("  ./scripts/cleanup-preview-env.ts --debug 634");
+	process.exit(1);
+}
+
+const prNumber = prNumberArg;
+
+console.log(`🧹 Cleaning up preview environment for PR #${prNumber}`);
+console.log(`   Worker: scorebrawl-pr-${prNumber}`);
+console.log(`   Database: scorebrawl-db-pr-${prNumber}`);
+console.log(`   Queues: scorebrawl-achievement-calculations-pr-${prNumber}, scorebrawl-seed-queue-pr-${prNumber}`);
+console.log(`   R2 Bucket: scorebrawl-user-assets-pr-${prNumber}`);
+console.log("");
+
+console.log("\n📋 Cleanup Sequence:");
+console.log("   1. Remove worker from queues");
+console.log("   2. Delete worker");
+console.log("   3. Delete queues");
+console.log("   4. Delete database");
+console.log("   5. Delete R2 bucket");
+console.log("");
+
+try {
+	const results = await runCleanup({ prNumber, debug });
+
+	// Print summary
+	console.log(`\n${"=".repeat(60)}`);
+	console.log("📊 CLEANUP SUMMARY");
+	console.log("=".repeat(60));
+
+	const successes = results.filter((r: CleanupResult) => r.status === "success").length;
+	const skipped = results.filter((r: CleanupResult) => r.status === "skipped").length;
+	const errors = results.filter((r: CleanupResult) => r.status === "error").length;
+
+	for (const result of results) {
+		const icon = result.status === "success" ? "✅" : result.status === "skipped" ? "⏭️" : "❌";
+		console.log(`${icon} ${result.step}: ${result.message}`);
+	}
+
+	console.log("-".repeat(60));
+	console.log(`Total: ${successes} succeeded, ${skipped} skipped, ${errors} errors`);
+	console.log("=".repeat(60));
+
+	if (errors > 0) {
+		console.log("\n⚠️  Some cleanup steps had errors. You may need to manually verify.");
+		process.exit(1);
+	} else {
+		console.log("\n✨ Cleanup completed successfully!");
+		process.exit(0);
+	}
+} catch (error) {
+	console.error("\n❌ Cleanup failed:", error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}

--- a/scripts/lib/cleanup.ts
+++ b/scripts/lib/cleanup.ts
@@ -172,14 +172,12 @@ export function validateSafetyCheck(
 	];
 	if (achievementQueueName && mainQueues.includes(achievementQueueName)) {
 		throw new Error(
-			`SAFETY CHECK FAILED: Cannot delete the main '${achievementQueueName}' queue! " +
-				"This script is for preview environments only (scorebrawl-*-pr-{N})`
+			`SAFETY CHECK FAILED: Cannot delete the main '${achievementQueueName}' queue! This script is for preview environments only (scorebrawl-*-pr-{N})`
 		);
 	}
 	if (seedQueueName && mainQueues.includes(seedQueueName)) {
 		throw new Error(
-			`SAFETY CHECK FAILED: Cannot delete the main '${seedQueueName}' queue! " +
-				"This script is for preview environments only (scorebrawl-*-pr-{N})`
+			`SAFETY CHECK FAILED: Cannot delete the main '${seedQueueName}' queue! This script is for preview environments only (scorebrawl-*-pr-{N})`
 		);
 	}
 }

--- a/scripts/lib/cleanup.ts
+++ b/scripts/lib/cleanup.ts
@@ -1,0 +1,354 @@
+#!/usr/bin/env bun
+/**
+ * Shared cleanup utilities for preview environments
+ * Used by both CI workflows and manual cleanup scripts
+ *
+ * Works with either:
+ * - Local wrangler authentication (OAuth) - preferred for local use
+ * - Environment variables (CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID) - for CI
+ */
+
+import { $ } from "bun";
+
+export interface CleanupConfig {
+	prNumber: string;
+	apiToken?: string;
+	accountId?: string;
+	debug?: boolean;
+}
+
+export interface CleanupResult {
+	step: string;
+	status: "success" | "skipped" | "error";
+	message: string;
+}
+
+// Global debug flag
+let debugMode = false;
+
+/**
+ * Log debug message if debug mode is enabled
+ */
+function debug(...args: unknown[]): void {
+	if (debugMode) {
+		console.log("🔍 DEBUG:", ...args);
+	}
+}
+
+/**
+ * Get account ID from wrangler (for local development)
+ */
+async function getAccountIdFromWrangler(): Promise<string | null> {
+	try {
+		const result = await $`bun wrangler whoami`.quiet();
+		const output = result.stdout.toString();
+		// Parse account ID from wrangler output
+		const match = output.match(/[a-f0-9]{32}/);
+		return match ? match[0] : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * List queues using wrangler CLI
+ * Parses table output format from wrangler queues list
+ */
+async function listQueues(): Promise<string[]> {
+	try {
+		const result = await $`bun wrangler queues list`.quiet();
+		const output = result.stdout.toString();
+		debug("Queues list output:", output);
+
+		// Parse table format with │ separators
+		// Format: │ id │ name │ created_on │ modified_on │ producers │ consumers │
+		const queues: string[] = [];
+		for (const line of output.split("\n")) {
+			// Skip header, footer, and separator lines
+			if (!line.includes("│") || line.includes("id") && line.includes("name")) {
+				continue;
+			}
+
+			// Split by │ and extract the name (second column)
+			const parts = line.split("│").map((p) => p.trim()).filter((p) => p.length > 0);
+			if (parts.length >= 2) {
+				const queueName = parts[1];
+				// Only include actual queue names (not headers)
+				if (queueName && !queueName.includes("-") && !queueName.includes("name")) {
+					queues.push(queueName);
+				}
+				if (queueName?.startsWith("scorebrawl")) {
+					queues.push(queueName);
+				}
+			}
+		}
+
+		debug("Parsed queues:", queues);
+		return [...new Set(queues)]; // Remove duplicates
+	} catch (error) {
+		debug("Error listing queues:", error);
+		return [];
+	}
+}
+
+/**
+ * List R2 buckets using wrangler CLI
+ */
+async function listR2Buckets(): Promise<string[]> {
+	try {
+		const result = await $`bun wrangler r2 bucket list`.quiet();
+		const output = result.stdout.toString();
+		debug("R2 buckets list output:", output);
+
+		// Parse bucket names from output
+		return output
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	} catch (error) {
+		debug("Error listing R2 buckets:", error);
+		return [];
+	}
+}
+
+/**
+ * Get resource names for a preview environment
+ */
+export function getResourceNames(prNumber: string) {
+	return {
+		workerName: `scorebrawl-pr-${prNumber}`,
+		achievementQueueName: `scorebrawl-achievement-calculations-pr-${prNumber}`,
+		seedQueueName: `scorebrawl-seed-queue-pr-${prNumber}`,
+		dbName: `scorebrawl-db-pr-${prNumber}`,
+		bucketName: `scorebrawl-user-assets-pr-${prNumber}`,
+	};
+}
+
+/**
+ * SAFETY CHECK: Validate that we're not trying to delete production resources
+ */
+export function validateSafetyCheck(workerName: string): void {
+	if (workerName === "scorebrawl") {
+		throw new Error(
+			"SAFETY CHECK FAILED: Cannot delete the main 'scorebrawl' worker! " +
+				"This script is for preview environments only (scorebrawl-pr-{N})"
+		);
+	}
+}
+
+/**
+ * Remove a worker as a consumer from a queue
+ */
+export async function removeQueueConsumer(
+	queueName: string,
+	workerName: string
+): Promise<CleanupResult> {
+	try {
+		const queues = await listQueues();
+		const queueExists = queues.includes(queueName);
+		debug(`Queue ${queueName} exists:`, queueExists);
+
+		if (queueExists) {
+			debug(`Removing consumer ${workerName} from ${queueName}...`);
+			const cmd = $`bun wrangler queues consumer remove ${queueName} ${workerName}`;
+			if (!debugMode) {
+				cmd.quiet();
+			}
+			await cmd;
+			return { step: `Remove consumer from ${queueName}`, status: "success", message: "Removed" };
+		}
+		return {
+			step: `Remove consumer from ${queueName}`,
+			status: "skipped",
+			message: "Queue not found",
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const stderr = (error as { stderr?: string }).stderr;
+		const fullMessage = stderr ? `${message}\n${stderr}` : message;
+		debug(`Error removing consumer from ${queueName}:`, fullMessage);
+
+		if (fullMessage.includes("not found") || fullMessage.includes("does not exist")) {
+			return {
+				step: `Remove consumer from ${queueName}`,
+				status: "skipped",
+				message: "Consumer not found",
+			};
+		}
+		return { step: `Remove consumer from ${queueName}`, status: "error", message: fullMessage };
+	}
+}
+
+/**
+ * Delete a Cloudflare Worker
+ */
+export async function deleteWorker(workerName: string): Promise<CleanupResult> {
+	try {
+		debug(`Deleting worker ${workerName}...`);
+		const cmd = $`bun wrangler delete --name ${workerName} --force`;
+		if (!debugMode) {
+			cmd.quiet();
+		}
+		await cmd;
+		return { step: "Delete Worker", status: "success", message: "Deleted" };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const stderr = (error as { stderr?: string }).stderr;
+		const fullMessage = stderr ? `${message}\n${stderr}` : message;
+		debug(`Error deleting worker ${workerName}:`, fullMessage);
+
+		if (fullMessage.includes("not found") || fullMessage.includes("does not exist")) {
+			return { step: "Delete Worker", status: "skipped", message: "Worker not found" };
+		}
+		return { step: "Delete Worker", status: "error", message: fullMessage };
+	}
+}
+
+/**
+ * Delete a queue
+ */
+export async function deleteQueue(queueName: string): Promise<CleanupResult> {
+	try {
+		const queues = await listQueues();
+		const queueExists = queues.includes(queueName);
+		debug(`Queue ${queueName} exists for deletion:`, queueExists);
+
+		if (queueExists) {
+			debug(`Deleting queue ${queueName}...`);
+			const cmd = $`bun wrangler queues delete ${queueName}`;
+			if (!debugMode) {
+				cmd.quiet();
+			}
+			await cmd;
+			return { step: `Delete Queue ${queueName}`, status: "success", message: "Deleted" };
+		}
+		return { step: `Delete Queue ${queueName}`, status: "skipped", message: "Queue not found" };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const stderr = (error as { stderr?: string }).stderr;
+		const fullMessage = stderr ? `${message}\n${stderr}` : message;
+		debug(`Error deleting queue ${queueName}:`, fullMessage);
+
+		return { step: `Delete Queue ${queueName}`, status: "error", message: fullMessage };
+	}
+}
+
+/**
+ * Delete a D1 database
+ */
+export async function deleteDatabase(dbName: string): Promise<CleanupResult> {
+	try {
+		debug(`Listing databases to check if ${dbName} exists...`);
+		const listResult = await $`bun wrangler d1 list --json`.quiet();
+		const databases = JSON.parse(listResult.stdout.toString());
+		const dbExists = databases.find((db: { name: string }) => db.name === dbName);
+		debug(`Database ${dbName} exists:`, !!dbExists);
+
+		if (dbExists) {
+			debug(`Deleting database ${dbName}...`);
+			const cmd = $`bun wrangler d1 delete ${dbName} --skip-confirmation`;
+			if (!debugMode) {
+				cmd.quiet();
+			}
+			await cmd;
+			return { step: "Delete Database", status: "success", message: "Deleted" };
+		}
+		return { step: "Delete Database", status: "skipped", message: "Database not found" };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const stderr = (error as { stderr?: string }).stderr;
+		const fullMessage = stderr ? `${message}\n${stderr}` : message;
+		debug(`Error deleting database ${dbName}:`, fullMessage);
+
+		return { step: "Delete Database", status: "error", message: fullMessage };
+	}
+}
+
+/**
+ * Delete an R2 bucket
+ */
+export async function deleteR2Bucket(bucketName: string): Promise<CleanupResult> {
+	try {
+		const buckets = await listR2Buckets();
+		const bucketExists = buckets.includes(bucketName);
+		debug(`Bucket ${bucketName} exists:`, bucketExists);
+
+		if (bucketExists) {
+			// First, remove all objects from the bucket
+			try {
+				debug(`Removing objects from bucket ${bucketName}...`);
+				const deleteCmd = $`bun wrangler r2 object delete --bucket ${bucketName} --prefix ""`;
+				if (!debugMode) {
+					deleteCmd.quiet();
+				}
+				await deleteCmd;
+			} catch {
+				// Bucket might be empty, continue
+				debug("No objects to delete or delete failed");
+			}
+
+			// Delete the bucket
+			debug(`Deleting bucket ${bucketName}...`);
+			const cmd = $`bun wrangler r2 bucket delete ${bucketName}`;
+			if (!debugMode) {
+				cmd.quiet();
+			}
+			await cmd;
+			return { step: "Delete R2 Bucket", status: "success", message: "Deleted" };
+		}
+		return { step: "Delete R2 Bucket", status: "skipped", message: "Bucket not found" };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const stderr = (error as { stderr?: string }).stderr;
+		const fullMessage = stderr ? `${message}\n${stderr}` : message;
+		debug(`Error deleting bucket ${bucketName}:`, fullMessage);
+
+		return { step: "Delete R2 Bucket", status: "error", message: fullMessage };
+	}
+}
+
+/**
+ * Run full cleanup sequence
+ * Works with local wrangler auth or CI environment variables
+ */
+export async function runCleanup(config: CleanupConfig): Promise<CleanupResult[]> {
+	const { prNumber, debug: isDebug } = config;
+
+	// Set global debug mode
+	debugMode = isDebug ?? false;
+
+	const names = getResourceNames(prNumber);
+	const results: CleanupResult[] = [];
+
+	// Safety check
+	validateSafetyCheck(names.workerName);
+
+	// For logging purposes, show account info if we can get it
+	const accountId = config.accountId ?? (await getAccountIdFromWrangler());
+	if (accountId) {
+		console.log(`   Using account: ${accountId}`);
+	}
+
+	if (debugMode) {
+		console.log("\n🔍 DEBUG MODE ENABLED - showing all command output\n");
+	}
+
+	// Step 1: Remove worker from both queues
+	results.push(await removeQueueConsumer(names.achievementQueueName, names.workerName));
+	results.push(await removeQueueConsumer(names.seedQueueName, names.workerName));
+
+	// Step 2: Delete worker
+	results.push(await deleteWorker(names.workerName));
+
+	// Step 3: Delete queues
+	results.push(await deleteQueue(names.achievementQueueName));
+	results.push(await deleteQueue(names.seedQueueName));
+
+	// Step 4: Delete database
+	results.push(await deleteDatabase(names.dbName));
+
+	// Step 5: Delete R2 bucket
+	results.push(await deleteR2Bucket(names.bucketName));
+
+	return results;
+}

--- a/scripts/lib/cleanup.ts
+++ b/scripts/lib/cleanup.ts
@@ -137,12 +137,49 @@ export function getResourceNames(prNumber: string) {
 
 /**
  * SAFETY CHECK: Validate that we're not trying to delete production resources
+ * Only preview resources (ending with -pr-{number}) can be deleted
  */
-export function validateSafetyCheck(workerName: string): void {
+export function validateSafetyCheck(
+	workerName: string,
+	bucketName?: string,
+	dbName?: string,
+	achievementQueueName?: string,
+	seedQueueName?: string
+): void {
 	if (workerName === "scorebrawl") {
 		throw new Error(
 			"SAFETY CHECK FAILED: Cannot delete the main 'scorebrawl' worker! " +
 				"This script is for preview environments only (scorebrawl-pr-{N})"
+		);
+	}
+	if (bucketName === "scorebrawl-user-assets") {
+		throw new Error(
+			"SAFETY CHECK FAILED: Cannot delete the main 'scorebrawl-user-assets' bucket! " +
+				"This script is for preview environments only (scorebrawl-user-assets-pr-{N})"
+		);
+	}
+	if (dbName === "scorebrawl") {
+		throw new Error(
+			"SAFETY CHECK FAILED: Cannot delete the main 'scorebrawl' database! " +
+				"This script is for preview environments only (scorebrawl-db-pr-{N})"
+		);
+	}
+	// Check for main queues (not preview ones)
+	const mainQueues = [
+		"achievement-calculations",
+		"scorebrawl-achievement-calculations",
+		"scorebrawl-seed-queue",
+	];
+	if (achievementQueueName && mainQueues.includes(achievementQueueName)) {
+		throw new Error(
+			`SAFETY CHECK FAILED: Cannot delete the main '${achievementQueueName}' queue! " +
+				"This script is for preview environments only (scorebrawl-*-pr-{N})`
+		);
+	}
+	if (seedQueueName && mainQueues.includes(seedQueueName)) {
+		throw new Error(
+			`SAFETY CHECK FAILED: Cannot delete the main '${seedQueueName}' queue! " +
+				"This script is for preview environments only (scorebrawl-*-pr-{N})`
 		);
 	}
 }
@@ -331,8 +368,14 @@ export async function runCleanup(config: CleanupConfig): Promise<CleanupResult[]
 	const names = getResourceNames(prNumber);
 	const results: CleanupResult[] = [];
 
-	// Safety check
-	validateSafetyCheck(names.workerName);
+	// Safety check - validate all resource names to prevent deletion of production resources
+	validateSafetyCheck(
+		names.workerName,
+		names.bucketName,
+		names.dbName,
+		names.achievementQueueName,
+		names.seedQueueName
+	);
 
 	// For logging purposes, show account info if we can get it
 	const accountId = config.accountId ?? (await getAccountIdFromWrangler());

--- a/scripts/lib/cleanup.ts
+++ b/scripts/lib/cleanup.ts
@@ -64,8 +64,8 @@ async function listQueues(): Promise<string[]> {
 		// Format: │ id │ name │ created_on │ modified_on │ producers │ consumers │
 		const queues: string[] = [];
 		for (const line of output.split("\n")) {
-			// Skip header, footer, and separator lines
-			if (!line.includes("│") || (line.includes("id") && line.includes("name"))) {
+			// Skip lines without table separators
+			if (!line.includes("│")) {
 				continue;
 			}
 
@@ -76,10 +76,7 @@ async function listQueues(): Promise<string[]> {
 				.filter((p) => p.length > 0);
 			if (parts.length >= 2) {
 				const queueName = parts[1];
-				// Only include actual queue names (not headers)
-				if (queueName && !queueName.includes("-") && !queueName.includes("name")) {
-					queues.push(queueName);
-				}
+				// Include scorebrawl queue names (preview queues have dashes)
 				if (queueName?.startsWith("scorebrawl")) {
 					queues.push(queueName);
 				}
@@ -96,6 +93,7 @@ async function listQueues(): Promise<string[]> {
 
 /**
  * List R2 buckets using wrangler CLI
+ * Parses output format: name: <bucket-name>
  */
 async function listR2Buckets(): Promise<string[]> {
 	try {
@@ -104,10 +102,20 @@ async function listR2Buckets(): Promise<string[]> {
 		debug("R2 buckets list output:", output);
 
 		// Parse bucket names from output
-		return output
-			.split("\n")
-			.map((line) => line.trim())
-			.filter((line) => line.length > 0);
+		// Format: name:           scorebrawl-user-assets
+		const buckets: string[] = [];
+		for (const line of output.split("\n")) {
+			const trimmed = line.trim();
+			if (trimmed.startsWith("name:")) {
+				const bucketName = trimmed.replace(/^name:\s*/, "").trim();
+				if (bucketName) {
+					buckets.push(bucketName);
+				}
+			}
+		}
+
+		debug("Parsed buckets:", buckets);
+		return buckets;
 	} catch (error) {
 		debug("Error listing R2 buckets:", error);
 		return [];
@@ -218,7 +226,7 @@ export async function deleteQueue(queueName: string): Promise<CleanupResult> {
 
 		if (queueExists) {
 			debug(`Deleting queue ${queueName}...`);
-			const cmd = $`bun wrangler queues delete ${queueName}`;
+			const cmd = $`bun wrangler queues delete ${queueName} --force`;
 			if (!debugMode) {
 				cmd.quiet();
 			}

--- a/scripts/lib/cleanup.ts
+++ b/scripts/lib/cleanup.ts
@@ -65,12 +65,15 @@ async function listQueues(): Promise<string[]> {
 		const queues: string[] = [];
 		for (const line of output.split("\n")) {
 			// Skip header, footer, and separator lines
-			if (!line.includes("│") || line.includes("id") && line.includes("name")) {
+			if (!line.includes("│") || (line.includes("id") && line.includes("name"))) {
 				continue;
 			}
 
 			// Split by │ and extract the name (second column)
-			const parts = line.split("│").map((p) => p.trim()).filter((p) => p.length > 0);
+			const parts = line
+				.split("│")
+				.map((p) => p.trim())
+				.filter((p) => p.length > 0);
 			if (parts.length >= 2) {
 				const queueName = parts[1];
 				// Only include actual queue names (not headers)


### PR DESCRIPTION
Fixes the preview cleanup failure where the worker couldn't be deleted because it was still a consumer for the seed-queue.

## Problem
The delete worker step in the cleanup workflow was failing with:
```
Cannot delete this Worker as it is a consumer for a Queue. Remove it from the Queue's consumers first, then retry. [code: 10064]
```

## Root Cause
The `remove-queue-consumer.ts` script only removed the worker from the `achievement-calculations` queue, but the preview creates **two** queues:
1. `scorebrawl-achievement-calculations-pr-{N}`
2. `scorebrawl-seed-queue-pr-{N}`

The worker is a consumer for both queues, so it couldn't be deleted while still attached to the seed-queue.

## Fix
Updated `remove-queue-consumer.ts` to remove the worker as a consumer from **both** queues before the worker deletion step runs.