### PR TITLE
fix(session): invert diversity shuffle weight selection

### DIFF
--- a/apps/worker/src/lib/shuffle.ts
+++ b/apps/worker/src/lib/shuffle.ts
@@ -21,12 +21,14 @@ export function diversityShuffle<T>(items: T[], pairWeights: Map<string, number>
 			return { item, score: totalWeight };
 		});
 
-		const totalScore = scored.reduce((sum, s) => sum + s.score + 1, 0);
-		let random = Math.random() * totalScore;
+		const maxScore = scored.reduce((max, s) => Math.max(max, s.score), 0);
+		const weightOf = (score: number) => maxScore - score + 1;
+		const totalWeight = scored.reduce((sum, s) => sum + weightOf(s.score), 0);
+		let random = Math.random() * totalWeight;
 		let selected = scored[0];
 
 		for (const s of scored) {
-			random -= s.score + 1;
+			random -= weightOf(s.score);
 			if (random < 0) {
 				selected = s;
 				break;

--- a/apps/worker/test/lib/session-rotation.spec.ts
+++ b/apps/worker/test/lib/session-rotation.spec.ts
@@ -231,6 +231,48 @@ describe("diversityShuffle", () => {
 			expect(new Set(shuffled).size).toBe(4);
 		}
 	});
+
+	const countAdjacencies = (shuffled: string[], x: string, y: string): number => {
+		const ix = shuffled.indexOf(x);
+		const iy = shuffled.indexOf(y);
+		return Math.abs(ix - iy) === 1 ? 1 : 0;
+	};
+
+	it("places frequent co-players adjacent far less often than random", () => {
+		const items = ["a", "b", "c", "d"];
+		const pairWeights = new Map<string, number>();
+		pairWeights.set("a|b", 1000);
+
+		const iterations = 1000;
+		let adjacencyCount = 0;
+		for (let i = 0; i < iterations; i++) {
+			const shuffled = diversityShuffle([...items], pairWeights);
+			adjacencyCount += countAdjacencies(shuffled, "a", "b");
+		}
+
+		const adjacencyRate = adjacencyCount / iterations;
+		// Random baseline for 4 items: 50% adjacency. Correct diversity keeps
+		// it well below that (theoretical floor ~16.67% — when c,d happen to
+		// be placed first, a,b inevitably end up adjacent at positions 2,3).
+		expect(adjacencyRate).toBeLessThan(0.25);
+	});
+
+	it("makes frequent pairs less adjacent than infrequent pairs", () => {
+		const items = ["a", "b", "c", "d"];
+		const pairWeights = new Map<string, number>();
+		pairWeights.set("a|b", 1000);
+
+		const iterations = 1000;
+		let frequentAdjacency = 0;
+		let infrequentAdjacency = 0;
+		for (let i = 0; i < iterations; i++) {
+			const shuffled = diversityShuffle([...items], pairWeights);
+			frequentAdjacency += countAdjacencies(shuffled, "a", "b");
+			infrequentAdjacency += countAdjacencies(shuffled, "c", "d");
+		}
+
+		expect(frequentAdjacency).toBeLessThan(infrequentAdjacency);
+	});
 });
 
 describe("fisherYatesShuffle", () => {


### PR DESCRIPTION
## Summary
- `diversityShuffle` had its weighted random selection inverted — players with **higher** pair weight (frequent co-players) had **higher** probability of being placed adjacent, the opposite of diversity
- Fix: invert weights via `maxScore - score + 1` so frequent co-players are separated
- Added statistical tests that would have caught this (prior test only checked no errors)

## Evidence (1000-iteration sim, pair `a|b` weight = 1000)
| | Frequent-pair adjacency |
|-|-|
| Before fix | **99.8%** (always adjacent) |
| After fix | **~16%** (near theoretical floor of 16.67%) |
| Random baseline | 50% |

The plan doc at `docs/superpowers/plans/2026-04-09-randomizer-type-selector.md:115-119` explicitly documented the intent (*"Lower accumulated weight = more diverse = higher chance"*) — the comment said one thing, the code did the opposite.

## Test plan
- [x] `bun run test -- --run test/lib/session-rotation.spec.ts` — 13/13 pass
- [ ] Run an actual session with `randomizerType: "diversity"` and verify frequent co-players get separated across teams

🤖 Generated with [Claude Code](https://claude.com/claude-code)