### PR TITLE
feat: add season selector to team detail page

### DIFF
--- a/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/teams/$teamId/index.tsx
+++ b/apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/teams/$teamId/index.tsx
@@ -1,10 +1,18 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
 import { Header } from "@/components/layout/header";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import {
 	PlayerAvatarGroupInline,
 	PlayerAvatarGroupGrid,
@@ -47,8 +55,13 @@ import {
 	type ChartConfig,
 } from "@/components/ui/chart";
 
+const teamSearchSchema = z.object({
+	season: z.string().optional(),
+});
+
 export const Route = createFileRoute("/_authenticated/_sidebar/leagues/$slug/teams/$teamId/")({
 	component: TeamProfilePage,
+	validateSearch: teamSearchSchema,
 	loader: async ({ params }) => {
 		return { slug: params.slug, teamId: params.teamId };
 	},
@@ -91,6 +104,7 @@ const matchResultsConfig = {
 
 function TeamProfilePage() {
 	const { slug, teamId } = Route.useLoaderData();
+	const navigate = useNavigate({ from: Route.fullPath });
 	const trpc = useTRPC();
 	const queryClient = useQueryClient();
 
@@ -100,12 +114,20 @@ function TeamProfilePage() {
 	const [logoPreview, setLogoPreview] = useState<string | null>(null);
 	const [isLogoRemoved, setIsLogoRemoved] = useState(false);
 
+	const { season: selectedSeasonId } = Route.useSearch();
+	const setSelectedSeasonId = (id: string | undefined) => {
+		navigate({ to: ".", search: (prev) => ({ ...prev, season: id }) });
+	};
+
 	const { data: activeMember } = authClient.useActiveMember();
 	const role = activeMember?.role;
 	const isEditor = role === "owner" || role === "admin" || role === "editor";
 
 	const { data: userSession } = authClient.useSession();
 	const currentUserId = userSession?.user?.id;
+
+	// Get available seasons
+	const { data: seasons } = useQuery(trpc.season.getAll.queryOptions());
 
 	const {
 		data: team,
@@ -118,19 +140,38 @@ function TeamProfilePage() {
 	);
 
 	const { data: allTimeStats, isLoading: allTimeStatsLoading } = useQuery(
-		trpc.leagueTeam.getAllTimeStats.queryOptions({ teamId })
+		trpc.leagueTeam.getAllTimeStats.queryOptions({
+			teamId,
+			seasonId: selectedSeasonId,
+		})
 	);
 
-	const { data: bestSeason, isLoading: bestSeasonLoading } = useQuery(
-		trpc.leagueTeam.getBestSeason.queryOptions({ teamId })
-	);
+	const { data: bestSeason, isLoading: bestSeasonLoading } = useQuery({
+		...trpc.leagueTeam.getBestSeason.queryOptions({
+			teamId,
+			seasonId: selectedSeasonId,
+		}),
+		enabled: !selectedSeasonId,
+	});
+
+	const { data: filteredSeason, isLoading: filteredSeasonLoading } = useQuery({
+		...trpc.leagueTeam.getBestSeason.queryOptions({
+			teamId,
+			seasonId: selectedSeasonId,
+		}),
+		enabled: !!selectedSeasonId,
+	});
 
 	const { data: seasonHistory, isLoading: seasonHistoryLoading } = useQuery(
 		trpc.leagueTeam.getSeasonHistory.queryOptions({ teamId })
 	);
 
 	const { data: recentMatches, isLoading: matchesLoading } = useQuery(
-		trpc.leagueTeam.getRecentMatches.queryOptions({ teamId, limit: 10 })
+		trpc.leagueTeam.getRecentMatches.queryOptions({
+			teamId,
+			limit: 10,
+			seasonId: selectedSeasonId,
+		})
 	);
 
 	const {
@@ -140,6 +181,7 @@ function TeamProfilePage() {
 	} = useQuery({
 		...trpc.leagueTeam.getRivalTeams.queryOptions({
 			teamId,
+			seasonId: selectedSeasonId,
 		}),
 		enabled: !!teamId && !!team,
 		retry: 2,
@@ -307,6 +349,15 @@ function TeamProfilePage() {
 			? Math.round(((allTimeStats.wins || 0) / allTimeStats.total) * 100)
 			: 0;
 
+	// Current score: use selected season if filtered, otherwise latest season from history
+	const latestSeason = seasonHistory?.[0];
+	const currentScore = selectedSeasonId ? filteredSeason?.score : latestSeason?.score;
+	const currentScoreLoading = selectedSeasonId ? filteredSeasonLoading : seasonHistoryLoading;
+
+	// Season display for card 4: selected season if filtered, otherwise best season
+	const seasonDisplay = selectedSeasonId ? filteredSeason : bestSeason;
+	const seasonDisplayLoading = selectedSeasonId ? filteredSeasonLoading : bestSeasonLoading;
+
 	const seasonChartData =
 		seasonHistory
 			?.map((h) => ({
@@ -444,26 +495,58 @@ function TeamProfilePage() {
 					</CardContent>
 				</Card>
 
+				{/* Season Selector */}
+				<div className="flex justify-end">
+					<Select
+						value={selectedSeasonId ?? "all"}
+						onValueChange={(val: string | null) =>
+							setSelectedSeasonId(val === "all" || !val ? undefined : val)
+						}
+					>
+						<SelectTrigger className="w-full sm:w-56">
+							<SelectValue>
+								{selectedSeasonId
+									? (seasons?.find((s) => s.id === selectedSeasonId)?.name ?? "All Seasons")
+									: "All Seasons"}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Seasons</SelectItem>
+							{seasons?.map((s) => (
+								<SelectItem key={s.id} value={s.id}>
+									{s.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
 				{/* Stats Overview */}
 				<div className="grid grid-cols-1 md:grid-cols-4 gap-4">
 					<Card className="relative overflow-hidden">
 						<div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(59,130,246,0.1),transparent_60%)]" />
 						<CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
 							<CardTitle className="text-sm font-medium text-muted-foreground">
-								Current Score
+								{selectedSeasonId ? "Season Score" : "Current Score"}
 							</CardTitle>
 							<HugeiconsIcon icon={Target01Icon} className="size-4 text-blue-600" />
 						</CardHeader>
 						<CardContent className="relative">
-							{bestSeasonLoading ? (
+							{currentScoreLoading ? (
 								<>
 									<Skeleton className="h-8 w-16 mb-2" />
 									<Skeleton className="h-4 w-20" />
 								</>
 							) : (
 								<>
-									<div className="text-2xl font-bold">{bestSeason?.score ?? "N/A"}</div>
-									<p className="text-xs text-muted-foreground">Current season</p>
+									<div className="text-2xl font-bold">{currentScore ?? "N/A"}</div>
+									<p className="text-xs text-muted-foreground">
+										{selectedSeasonId
+											? (seasons?.find((s) => s.id === selectedSeasonId)?.name ?? "Selected season")
+											: latestSeason
+												? `Current: ${latestSeason.season}`
+												: "No seasons"}
+									</p>
 								</>
 							)}
 						</CardContent>
@@ -496,7 +579,7 @@ function TeamProfilePage() {
 						<div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(245,158,11,0.1),transparent_60%)]" />
 						<CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
 							<CardTitle className="text-sm font-medium text-muted-foreground">
-								Total Matches
+								{selectedSeasonId ? "Matches" : "Total Matches"}
 							</CardTitle>
 							<HugeiconsIcon icon={UserMultiple02Icon} className="size-4 text-amber-600" />
 						</CardHeader>
@@ -510,8 +593,9 @@ function TeamProfilePage() {
 								<>
 									<div className="text-2xl font-bold">{allTimeStats?.total ?? 0}</div>
 									<p className="text-xs text-muted-foreground">
-										Across {allTimeStats?.seasonCount ?? 0} season
-										{(allTimeStats?.seasonCount ?? 0) !== 1 ? "s" : ""}
+										{selectedSeasonId
+											? "In selected season"
+											: `Across ${allTimeStats?.seasonCount ?? 0} season${(allTimeStats?.seasonCount ?? 0) !== 1 ? "s" : ""}`}
 									</p>
 								</>
 							)}
@@ -522,21 +606,23 @@ function TeamProfilePage() {
 						<div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(139,92,246,0.1),transparent_60%)]" />
 						<CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
 							<CardTitle className="text-sm font-medium text-muted-foreground">
-								Best Season
+								{selectedSeasonId ? "Season" : "Best Season"}
 							</CardTitle>
 							<HugeiconsIcon icon={Calendar01Icon} className="size-4 text-purple-600" />
 						</CardHeader>
 						<CardContent className="relative">
-							{bestSeasonLoading ? (
+							{seasonDisplayLoading ? (
 								<>
 									<Skeleton className="h-8 w-16 mb-2" />
 									<Skeleton className="h-4 w-20" />
 								</>
-							) : bestSeason ? (
+							) : seasonDisplay ? (
 								<>
-									<div className="text-2xl font-bold">{bestSeason.season}</div>
+									<div className="text-2xl font-bold">{seasonDisplay.season}</div>
 									<p className="text-xs text-muted-foreground">
-										Peak: {bestSeason.score} ({bestSeason.matches} matches)
+										{selectedSeasonId
+											? `Score: ${seasonDisplay.score} (${seasonDisplay.matches} matches)`
+											: `Peak: ${seasonDisplay.score} (${seasonDisplay.matches} matches)`}
 									</p>
 								</>
 							) : (

--- a/apps/worker/src/repositories/team-repository.ts
+++ b/apps/worker/src/repositories/team-repository.ts
@@ -98,7 +98,20 @@ export const getTeamPlayersWithDetails = async ({
 		.where(eq(leagueTeamPlayer.leagueTeamId, teamId));
 };
 
-export const getAllTimeStats = async ({ db, teamId }: { db: DrizzleDB; teamId: string }) => {
+export const getAllTimeStats = async ({
+	db,
+	teamId,
+	seasonId,
+}: {
+	db: DrizzleDB;
+	teamId: string;
+	seasonId?: string;
+}) => {
+	const conditions = [eq(seasonTeam.leagueTeamId, teamId)];
+	if (seasonId) {
+		conditions.push(eq(seasonTeam.seasonId, seasonId));
+	}
+
 	const stats = await db
 		.select({
 			total: sql<number>`count(*)`,
@@ -109,12 +122,25 @@ export const getAllTimeStats = async ({ db, teamId }: { db: DrizzleDB; teamId: s
 		})
 		.from(matchTeam)
 		.innerJoin(seasonTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
-		.where(eq(seasonTeam.leagueTeamId, teamId));
+		.where(and(...conditions));
 
 	return stats[0] || { total: 0, wins: 0, losses: 0, draws: 0, seasonCount: 0 };
 };
 
-export const getBestSeason = async ({ db, teamId }: { db: DrizzleDB; teamId: string }) => {
+export const getBestSeason = async ({
+	db,
+	teamId,
+	seasonId,
+}: {
+	db: DrizzleDB;
+	teamId: string;
+	seasonId?: string;
+}) => {
+	const conditions = [eq(seasonTeam.leagueTeamId, teamId)];
+	if (seasonId) {
+		conditions.push(eq(seasonTeam.seasonId, seasonId));
+	}
+
 	const [best] = await db
 		.select({
 			seasonName: season.name,
@@ -127,9 +153,9 @@ export const getBestSeason = async ({ db, teamId }: { db: DrizzleDB; teamId: str
 		.from(seasonTeam)
 		.innerJoin(season, eq(seasonTeam.seasonId, season.id))
 		.leftJoin(matchTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
-		.where(eq(seasonTeam.leagueTeamId, teamId))
+		.where(and(...conditions))
 		.groupBy(seasonTeam.id, season.id)
-		.orderBy(desc(seasonTeam.score))
+		.orderBy(seasonId ? desc(season.startDate) : desc(seasonTeam.score))
 		.limit(1);
 
 	if (!best) {
@@ -184,11 +210,18 @@ export const getRecentMatches = async ({
 	db,
 	teamId,
 	limit,
+	seasonId,
 }: {
 	db: DrizzleDB;
 	teamId: string;
 	limit: number;
+	seasonId?: string;
 }) => {
+	const conditions = [eq(seasonTeam.leagueTeamId, teamId)];
+	if (seasonId) {
+		conditions.push(eq(seasonTeam.seasonId, seasonId));
+	}
+
 	// First, get the match IDs for our team's recent matches, ordered by match.createdAt
 	const ourMatchIds = await db
 		.select({
@@ -198,7 +231,7 @@ export const getRecentMatches = async ({
 		.from(matchTeam)
 		.innerJoin(seasonTeam, eq(matchTeam.seasonTeamId, seasonTeam.id))
 		.innerJoin(match, eq(matchTeam.matchId, match.id))
-		.where(eq(seasonTeam.leagueTeamId, teamId))
+		.where(and(...conditions))
 		.orderBy(desc(match.createdAt))
 		.limit(limit);
 
@@ -338,12 +371,18 @@ export interface RivalTeam {
 export const getRivalTeams = async ({
 	db,
 	teamId,
+	seasonId,
 }: {
 	db: DrizzleDB;
 	teamId: string;
+	seasonId?: string;
 }): Promise<{ bestRival: RivalTeam | null; worstRival: RivalTeam | null }> => {
 	// Use a single, optimized query to get rival statistics
 	// This counts matches grouped by opponent team
+	const whereClause = seasonId
+		? sql`our_season_team.league_team_id = ${teamId} AND our_season_team.season_id = ${seasonId}`
+		: sql`our_season_team.league_team_id = ${teamId}`;
+
 	const rivalStats = await db
 		.select({
 			opponentTeamId: sql<string>`opponent_league_team.id`,
@@ -367,7 +406,7 @@ export const getRivalTeams = async ({
 			sql`league_team opponent_league_team`,
 			sql`opponent_season_team.league_team_id = opponent_league_team.id`
 		)
-		.where(sql`our_season_team.league_team_id = ${teamId}`)
+		.where(whereClause)
 		.groupBy(sql`opponent_league_team.id, opponent_league_team.name, opponent_league_team.logo`)
 		.having(sql`COUNT(*) >= 2`) // Only teams with 2+ matches
 		.orderBy(sql`COUNT(*) DESC`) // Order by most matches first

--- a/apps/worker/src/trpc/router/league-team-router.ts
+++ b/apps/worker/src/trpc/router/league-team-router.ts
@@ -499,7 +499,7 @@ export const leagueTeamRouter = {
 		}),
 
 	getAllTimeStats: leagueProcedure
-		.input(z.object({ teamId: z.string() }))
+		.input(z.object({ teamId: z.string(), seasonId: z.string().optional() }))
 		.query(async ({ input, ctx }) => {
 			const team = await teamRepository.getById({
 				db: ctx.db,
@@ -517,11 +517,12 @@ export const leagueTeamRouter = {
 			return teamRepository.getAllTimeStats({
 				db: ctx.db,
 				teamId: input.teamId,
+				seasonId: input.seasonId,
 			});
 		}),
 
 	getBestSeason: leagueProcedure
-		.input(z.object({ teamId: z.string() }))
+		.input(z.object({ teamId: z.string(), seasonId: z.string().optional() }))
 		.query(async ({ input, ctx }) => {
 			const team = await teamRepository.getById({
 				db: ctx.db,
@@ -539,6 +540,7 @@ export const leagueTeamRouter = {
 			return teamRepository.getBestSeason({
 				db: ctx.db,
 				teamId: input.teamId,
+				seasonId: input.seasonId,
 			});
 		}),
 
@@ -565,7 +567,13 @@ export const leagueTeamRouter = {
 		}),
 
 	getRecentMatches: leagueProcedure
-		.input(z.object({ teamId: z.string(), limit: z.number().default(10) }))
+		.input(
+			z.object({
+				teamId: z.string(),
+				limit: z.number().default(10),
+				seasonId: z.string().optional(),
+			})
+		)
 		.query(async ({ input, ctx }) => {
 			const team = await teamRepository.getById({
 				db: ctx.db,
@@ -584,11 +592,12 @@ export const leagueTeamRouter = {
 				db: ctx.db,
 				teamId: input.teamId,
 				limit: input.limit,
+				seasonId: input.seasonId,
 			});
 		}),
 
 	getRivalTeams: leagueProcedure
-		.input(z.object({ teamId: z.string() }))
+		.input(z.object({ teamId: z.string(), seasonId: z.string().optional() }))
 		.query(async ({ input, ctx }) => {
 			const team = await teamRepository.getById({
 				db: ctx.db,
@@ -606,6 +615,7 @@ export const leagueTeamRouter = {
 			return teamRepository.getRivalTeams({
 				db: ctx.db,
 				teamId: input.teamId,
+				seasonId: input.seasonId,
 			});
 		}),
 } satisfies TRPCRouterRecord;


### PR DESCRIPTION
## Summary

- Adds a season dropdown filter to the team profile page (same pattern as player comparison)
- Updates backend team endpoints to accept an optional `seasonId`:
  - `leagueTeam.getAllTimeStats`
  - `leagueTeam.getBestSeason`
  - `leagueTeam.getRecentMatches`
  - `leagueTeam.getRivalTeams`
- Fixes the "Current Score" stat card: it was showing the best-ever season score while labeling it "Current season". Now it correctly shows the **latest** season's score with the season name.
- Stats cards dynamically relabel when a specific season is selected (e.g. "Current Score" → "Season Score", "Total Matches" → "Matches", "Best Season" → "Season")

## Verification

- `bun check` passes
- Typecheck passes
- Verified in browser that stats match database values exactly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->