### PR TITLE
fix: avoid SQLite param limit in MCP tools

### DIFF
--- a/apps/worker/src/services/mcp-tools/tool-executors.ts
+++ b/apps/worker/src/services/mcp-tools/tool-executors.ts
@@ -50,28 +50,18 @@ async function fetchMatchPlayerRows(
 		const nameLower = playerName.toLowerCase();
 		const pattern = `%${nameLower}%`;
 
-		const playerMatchRows = await db
-			.select({ matchId: match.id })
-			.from(match)
-			.innerJoin(season, eq(season.id, match.seasonId))
-			.innerJoin(matchPlayer, eq(matchPlayer.matchId, match.id))
+		const playerMatchSubquery = db
+			.select({ matchId: matchPlayer.matchId })
+			.from(matchPlayer)
 			.innerJoin(seasonPlayer, eq(seasonPlayer.id, matchPlayer.seasonPlayerId))
 			.innerJoin(player, eq(player.id, seasonPlayer.playerId))
 			.leftJoin(user, eq(user.id, player.userId))
 			.leftJoin(guest, eq(guest.id, player.guestId))
 			.where(
-				and(
-					...conditions,
-					or(
-						like(sql`LOWER(${user.name})`, pattern),
-						like(sql`LOWER(${guest.displayName})`, pattern)
-					)
-				)
+				or(like(sql`LOWER(${user.name})`, pattern), like(sql`LOWER(${guest.displayName})`, pattern))
 			);
 
-		const matchIds = [...new Set(playerMatchRows.map((r) => r.matchId))];
-		if (matchIds.length === 0) return [];
-		conditions.push(inArray(match.id, matchIds));
+		conditions.push(inArray(match.id, playerMatchSubquery));
 	}
 
 	return db
@@ -376,35 +366,27 @@ export async function getHeadToHead(
 	const conditions = [eq(season.leagueId, args.leagueId)];
 	if (args.seasonSlug) conditions.push(eq(season.slug, args.seasonSlug));
 
-	const findPlayerMatchIds = async (name: string) => {
-		const rows = await db
-			.select({ matchId: match.id })
-			.from(match)
-			.innerJoin(season, eq(season.id, match.seasonId))
-			.innerJoin(matchPlayer, eq(matchPlayer.matchId, match.id))
+	const buildPlayerSubquery = (name: string) => {
+		return db
+			.select({ matchId: matchPlayer.matchId })
+			.from(matchPlayer)
 			.innerJoin(seasonPlayer, eq(seasonPlayer.id, matchPlayer.seasonPlayerId))
 			.innerJoin(player, eq(player.id, seasonPlayer.playerId))
 			.leftJoin(user, eq(user.id, player.userId))
 			.leftJoin(guest, eq(guest.id, player.guestId))
 			.where(
-				and(
-					...conditions,
-					or(
-						like(sql`LOWER(${user.name})`, `%${name}%`),
-						like(sql`LOWER(${guest.displayName})`, `%${name}%`)
-					)
+				or(
+					like(sql`LOWER(${user.name})`, `%${name}%`),
+					like(sql`LOWER(${guest.displayName})`, `%${name}%`)
 				)
 			);
-		return [...new Set(rows.map((r) => r.matchId))];
 	};
 
-	const p1MatchIds = await findPlayerMatchIds(name1Lower);
-	const p2MatchIds = await findPlayerMatchIds(name2Lower);
-	const sharedMatchIds = p1MatchIds.filter((id) => p2MatchIds.includes(id));
+	const p1Subquery = buildPlayerSubquery(name1Lower);
+	const p2Subquery = buildPlayerSubquery(name2Lower);
 
-	if (sharedMatchIds.length === 0) {
-		return { error: `No matches found between "${args.player1Name}" and "${args.player2Name}"` };
-	}
+	conditions.push(inArray(match.id, p1Subquery));
+	conditions.push(inArray(match.id, p2Subquery));
 
 	const allMatchPlayers = await db
 		.select({
@@ -428,8 +410,13 @@ export async function getHeadToHead(
 		.innerJoin(season, eq(season.id, match.seasonId))
 		.leftJoin(user, eq(user.id, player.userId))
 		.leftJoin(guest, eq(guest.id, player.guestId))
-		.where(inArray(match.id, sharedMatchIds))
+		.where(and(...conditions))
 		.orderBy(desc(match.createdAt));
+
+	const sharedMatchIds = [...new Set(allMatchPlayers.map((mp) => mp.matchId))];
+	if (sharedMatchIds.length === 0) {
+		return { error: `No matches found between "${args.player1Name}" and "${args.player2Name}"` };
+	}
 
 	let p1Wins = 0;
 	let p2Wins = 0;

--- a/apps/worker/src/services/mcp-tools/tool-executors.ts
+++ b/apps/worker/src/services/mcp-tools/tool-executors.ts
@@ -55,10 +55,19 @@ async function fetchMatchPlayerRows(
 			.from(matchPlayer)
 			.innerJoin(seasonPlayer, eq(seasonPlayer.id, matchPlayer.seasonPlayerId))
 			.innerJoin(player, eq(player.id, seasonPlayer.playerId))
+			.innerJoin(match, eq(match.id, matchPlayer.matchId))
+			.innerJoin(season, eq(season.id, match.seasonId))
 			.leftJoin(user, eq(user.id, player.userId))
 			.leftJoin(guest, eq(guest.id, player.guestId))
 			.where(
-				or(like(sql`LOWER(${user.name})`, pattern), like(sql`LOWER(${guest.displayName})`, pattern))
+				and(
+					eq(season.leagueId, leagueId),
+					seasonSlug ? eq(season.slug, seasonSlug) : undefined,
+					or(
+						like(sql`LOWER(${user.name})`, pattern),
+						like(sql`LOWER(${guest.displayName})`, pattern)
+					)
+				)
 			);
 
 		conditions.push(inArray(match.id, playerMatchSubquery));
@@ -372,12 +381,18 @@ export async function getHeadToHead(
 			.from(matchPlayer)
 			.innerJoin(seasonPlayer, eq(seasonPlayer.id, matchPlayer.seasonPlayerId))
 			.innerJoin(player, eq(player.id, seasonPlayer.playerId))
+			.innerJoin(match, eq(match.id, matchPlayer.matchId))
+			.innerJoin(season, eq(season.id, match.seasonId))
 			.leftJoin(user, eq(user.id, player.userId))
 			.leftJoin(guest, eq(guest.id, player.guestId))
 			.where(
-				or(
-					like(sql`LOWER(${user.name})`, `%${name}%`),
-					like(sql`LOWER(${guest.displayName})`, `%${name}%`)
+				and(
+					eq(season.leagueId, args.leagueId),
+					args.seasonSlug ? eq(season.slug, args.seasonSlug) : undefined,
+					or(
+						like(sql`LOWER(${user.name})`, `%${name}%`),
+						like(sql`LOWER(${guest.displayName})`, `%${name}%`)
+					)
 				)
 			);
 	};


### PR DESCRIPTION
**Problem**
`fetchMatchPlayerRows` and `getHeadToHead` collected match IDs in JS, then passed them back via `inArray(...)`. For high-volume players (e.g. ~3.7k matches), this overflowed SQLite's bound-parameter limit (999).

**Fix**
Replace the two-step query → collect → re-query pattern with single SQL queries using Drizzle subqueries.
- `fetchMatchPlayerRows`: `inArray(match.id, playerMatchSubquery)`
- `getHeadToHead`: two player subqueries intersected directly in SQL

**Verification**
- `bun check` passes (0 errors)
- MCP router tests pass
- All downstream tools (`getPlayerStats`, `getTeamChemistry`, `getStreaks`, etc.) inherit the fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783077089&installation_id=127764750&pr_number=646&repository=thor-coding-cowboys%2Fscorebrawl&return_to=https%3A%2F%2Fgithub.com%2Fthor-coding-cowboys%2Fscorebrawl%2Fpull%2F646&signature=b944e56ca0f43383a9d5edd50ff9fa37c6132dd60041a8ee5733369399374169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->