### PR TITLE
docs: prioritized feature backlog (docs/features)

### DIFF
--- a/docs/features/01-in-app-notifications.md
+++ b/docs/features/01-in-app-notifications.md
@@ -1,0 +1,38 @@
+# In-App Notifications
+
+## Summary
+
+A notification inbox so users see streaks, new matches, achievements, and session events without having to poll every page.
+
+## Why / Goal
+
+The app already generates rich events (matches, streaks, sessions) via SSE but nothing surfaces them to the user. Notifications are the highest-leverage retention feature and the foundation for future push/mobile.
+
+## Scope
+
+- New `notification` table (recipient, type, actor, payload JSON, read flag, created_at)
+- Notification creation hooks where events already fire (match create/remove, streak thresholds, session start/end, achievements)
+- Notification router (list, mark-read, unread count, mark-all-read)
+- Notification bell in the app header (sidebar) with unread badge
+- Notification dropdown + full list page
+- Live updates via the existing SSE/WebSocket infra
+
+## Code map
+
+- Events originate in: `apps/worker/src/trpc/router/match-router.ts`, `session-router.ts`
+- SSE infra: `apps/worker/src/durable-objects/season-sse.ts`, `apps/worker/src/routes/sse-router.ts`
+- Frontend hooks: `apps/web/src/hooks/use-session-sse.ts`
+- Header/sidebar: `apps/web/src/routes/-components/layout/header.tsx`, `-components/sidebar/*`
+
+## Acceptance criteria
+
+- Bell shows unread count; badge updates live via SSE
+- Clicking a notification navigates to the relevant entity (match/session/achievement)
+- Mark single / mark all read
+- Notifications generated for: new match, streak milestone, achievement earned, session started/ended
+
+## Open questions / notes
+
+- Scope of notifications per season vs per league vs global
+- Should SSO/email notifications be added later (not in this story)
+- Deletion/retention policy for notifications

--- a/docs/features/02-achievements-showcase.md
+++ b/docs/features/02-achievements-showcase.md
@@ -1,0 +1,36 @@
+# Achievements Showcase & Celebration
+
+## Summary
+
+Surface the 13 achievement types already computed in the backend as visible, celebratory UI on profiles and league pages.
+
+## Why / Goal
+
+The achievement engine fully works but players never see it — profiles just say "No achievements yet". This makes progression tangible and drives engagement.
+
+## Scope
+
+- Achievement card grid on player profile (earned + locked states, date earned)
+- League-wide achievements board (who has what, most decorated players)
+- Toast/banner celebration when an achievement unlocks (leveraging `streak`/event infra)
+- Achievement metadata (name, description, icon) centralized in one place
+- Empty state improvements (show locked achievements so players know what to chase)
+
+## Code map
+
+- Engine: `apps/worker/src/services/achievement-calculation.ts`, `achievement-repository.ts`
+- Router: `apps/worker/src/trpc/router/achievement-router.ts` (`getByPlayerId`)
+- Profile UI: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/players/$leaguePlayerId/index.tsx`
+- Achievement types list is in `achievement-calculation.ts` (5/10/15 win streak, clean sheets, redemptions, goals, season winner)
+
+## Acceptance criteria
+
+- Player profile shows all 13 achievement types with earned/locked state
+- League achievements board renders from a single query
+- Unlock fires an in-app celebration (can depend on 01-notifications)
+- Achievement metadata is defined once and reused
+
+## Open questions / notes
+
+- `season_winner` achievement is declared but never computed — see 03-season-close-ceremony
+- Iconography: use Hugeicons; need a per-type icon mapping

--- a/docs/features/03-season-close-ceremony.md
+++ b/docs/features/03-season-close-ceremony.md
@@ -1,0 +1,36 @@
+# Season Close Ceremony & Champion Crowning
+
+## Summary
+
+A satisfying end-of-season flow: closing a season crowns the champion, awards the `season_winner` achievement (currently declared but never computed), and shows a podium/ceremony view.
+
+## Why / Goal
+
+Seasons can currently be closed ("Lock Season") but nothing celebrates the result. This completes the core product loop (start season → compete → crown champion → repeat) and gives players a reason to return.
+
+## Scope
+
+- Compute and award `season_winner` achievement to the top player/team when a season closes
+- Season champion banner/podium view (leader, final standings, stats)
+- Season summary page showing final placements, champion, biggest moments
+- "Start next season" CTA from the ceremony view
+- Ensure awards are idempotent (no duplicate achievements if closed twice)
+
+## Code map
+
+- Season close: `apps/worker/src/trpc/router/season-router.ts` (`updateClosedStatus`), `season-repository.ts`
+- Achievement engine: `apps/worker/src/services/achievement-calculation.ts` (add `season_winner` path)
+- Season detail UI: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx`
+- Close dialog: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/-components/seasons/close-season-dialog.tsx`
+
+## Acceptance criteria
+
+- Closing a season awards `season_winner` exactly once to the champion
+- Champion/ceremony view renders with final standings
+- Re-opening a closed season and re-closing does not duplicate achievements
+- Pairs with 02-achievements-showcase for display
+
+## Open questions / notes
+
+- Champion for team-based (3-1-0) seasons: top player vs top team
+- Should closing be irreversible (currently `closed` blocks match creation)? Keep existing behavior.

--- a/docs/features/04-league-activity-feed.md
+++ b/docs/features/04-league-activity-feed.md
@@ -1,0 +1,36 @@
+# League Activity Feed
+
+## Summary
+
+A "what happened" timeline per league/season showing recent matches, streaks, records, and milestones as they occur.
+
+## Why / Goal
+
+The app produces a huge amount of analytics but there is no single place to see league activity at a glance. An activity feed turns the stored match/streak data into a living story and gives the league dashboard a natural centerpiece.
+
+## Scope
+
+- Activity feed query aggregating recent events: matches recorded, streaks hit, achievements earned, sessions started/ended, records broken
+- Feed timeline UI on the season dashboard (replacing/augmenting "Latest Match")
+- Load more / pagination
+- Optionally: activity feed page per league across all seasons
+- Live updates via existing SSE
+
+## Code map
+
+- Match events: `apps/worker/src/trpc/router/match-router.ts` (+ `match-repository.ts` streak detection)
+- Weekly/period stats already available: `seasonPlayer.getWeeklyStats`, `seasonTeam.getWeeklyStats`
+- Season dashboard: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/index.tsx` and `-components/season/*`
+- Records/upsets logic exists in MCP tools: `apps/worker/src/services/mcp-tools/tool-executors.ts`
+
+## Acceptance criteria
+
+- Season dashboard shows a chronological activity feed
+- Feed updates live via SSE (new match/streak/achievement appears without refresh)
+- Feed is paginated and performant (single aggregate query, no N+1)
+- Each feed item links to the relevant match/player/achievement
+
+## Open questions / notes
+
+- Which event types to include in v1 (start with match + streak)
+- Whether to build a dedicated activity log table or derive from existing match/streak data

--- a/docs/features/05-team-management-crud.md
+++ b/docs/features/05-team-management-crud.md
@@ -1,0 +1,37 @@
+# Team Management (Create / Edit / Roster)
+
+## Summary
+
+Full CRUD for teams. Today teams are only auto-created from match lineups; owners/editors cannot create named teams up front, manage rosters, or delete them.
+
+## Why / Goal
+
+Teams are a first-class concept (standings, profiles, rivalries) but management is invisible. Fixed teams (e.g. office pool pairs, real clubs) can't be pre-registered, and members can't be added/removed cleanly.
+
+## Scope
+
+- Create team with name + optional logo
+- Edit team name/logo
+- Add / remove players from a team roster (repo functions already exist)
+- Delete team (with rules about teams that have season/match history)
+- Optional: pre-register teams for a season before matches start
+- Team list filters (already has "My teams" switch)
+
+## Code map
+
+- Router gap: `apps/worker/src/trpc/router/league-team-router.ts` (no create/delete/member procedures)
+- Ready-to-use repo fns: `apps/worker/src/repositories/team-repository.ts` (`addPlayerToTeam`, `removePlayerFromTeam`)
+- Teams page: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/teams/index.tsx`
+- Team detail: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/teams/$teamId/index.tsx`
+
+## Acceptance criteria
+
+- Owner/editor can create, rename, and delete teams
+- Roster add/remove works and reflects in team profile + standings
+- Deleting a team with match history is blocked or shows a clear warning
+- Permissions: only owner/editor (and team members for name) per existing `leagueTeam.edit` rule
+
+## Open questions / notes
+
+- Deleting a team that has matches: what happens to historical records (soft-delete vs block)?
+- Should auto-created teams from lineups be mergeable/renamable into permanent teams?

--- a/docs/features/06-manual-session-lineup.md
+++ b/docs/features/06-manual-session-lineup.md
@@ -1,0 +1,34 @@
+# Manual Session Lineup Assist
+
+## Summary
+
+Make the `manual` rotation mode functional: it currently has no auto lineup — `computeManualLineup()` returns `null`, so the "Next Match" panel is empty.
+
+## Why / Goal
+
+The manual mode UI (team picker, live score sync) exists and works, but without a proposed lineup it's a weaker experience than winner-stays. This gives manual sessions a sensible default pairing while still allowing full manual override.
+
+## Scope
+
+- Implement lineup proposal for manual mode: pick next players who haven't played recently / haven't paired together (reuse diversity-shuffle heuristics)
+- Respect team size, available (non-playing) players, queue state
+- Keep the manual team picker override fully working
+- Add tests for the strategy
+
+## Code map
+
+- Stub: `apps/worker/src/services/session/strategies/manual.ts` (`computeManualLineup` returns `null`)
+- Working reference: `apps/worker/src/services/session/strategies/winner-stays.ts` + session queue logic in `apps/worker/src/services/session/session-service.ts`
+- Manual UI: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/session/$sessionId/-components/manual/manual-session.tsx` and `team-picker.tsx`
+- Tests: `apps/worker/src/test/trpc/` (see session tests)
+
+## Acceptance criteria
+
+- Starting a manual session shows a proposed lineup when enough players are available
+- Proposed lineup is editable before starting the match
+- Lineup logic prefers diverse pairings (no repeat partners) when possible
+- Existing manual team-picker behavior is unchanged
+
+## Open questions / notes
+
+- Should manual mode lineups auto-advance queue state, or purely be a suggestion? (Recommend: suggestion only, winner-stays keeps the queue rules)

--- a/docs/features/07-fixtures-points-season-ux.md
+++ b/docs/features/07-fixtures-points-season-ux.md
@@ -1,0 +1,36 @@
+# Fixtures & Points-Season (3-1-0) UX
+
+## Summary
+
+Polish the round-robin / scheduled-match experience for 3-1-0 points seasons. Fixtures are auto-generated but have minimal UI and no easy way to enter results.
+
+## Why / Goal
+
+3-1-0 seasons (league-style, e.g. office football) generate a full fixture schedule on creation, but users can only see a basic fixtures list and enter results one-by-one. A proper fixture UI makes points seasons competitive and easy to run.
+
+## Scope
+
+- Fixtures overview page: rounds, date, home/away, result state (played/pending)
+- Enter/edit result directly from a fixture row (`createFromFixture` exists)
+- Per-round grouping + round navigation
+- Standings that update with fixture results (3-1-0 standings already exist via `seasonPlayer.getStanding`)
+- Fixture re-schedule/swap (optional, stretch)
+
+## Code map
+
+- Fixture generation: `apps/worker/src/repositories/season-repository.ts` (circle method), triggered in `season-router.ts` `create`
+- Fixture result entry: `apps/worker/src/trpc/router/match-router.ts` (`createFromFixture`)
+- Fixtures component: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/-components/season/fixtures.tsx`
+- Season page tabs already switch views; add fixtures tab
+
+## Acceptance criteria
+
+- Fixtures render grouped by round with played/pending state
+- Clicking an unplayed fixture opens the score entry for that fixture
+- Entering a result updates standings immediately
+- Works for single-player 3-1-0 seasons (that's the mode fixtures are generated for)
+
+## Open questions / notes
+
+- Should fixtures be supported for ELO seasons too, or keep 3-1-0 only for now?
+- Re-scheduling fixtures is likely a later iteration

--- a/docs/features/08-standings-realtime-sse.md
+++ b/docs/features/08-standings-realtime-sse.md
@@ -1,0 +1,32 @@
+# Real-Time Standings via SSE
+
+## Summary
+
+Emit the `standings:update` SSE event (declared in the event type but never sent) so standings refresh live without manual reload.
+
+## Why / Goal
+
+Match insert/delete already broadcasts via SSE, but standings are computed separately and don't push. Two users in a session or an office league watching a match expect the table to update in real time. Small change, big perceived responsiveness.
+
+## Scope
+
+- Emit `standings:update` after match create / remove / session recordResult (and match score updates)
+- Frontend: subscribe to the event and invalidate the standings query
+- Optionally include the computed standings payload in the event to avoid a refetch
+
+## Code map
+
+- Event type: `apps/worker/src/durable-objects/season-sse.ts` (`SeasonSSEEvent`, `standings:update` already in union, never emitted)
+- Broadcast sites: `apps/worker/src/trpc/router/match-router.ts`, `session-router.ts`
+- Frontend hooks: `apps/web/src/hooks/use-session-sse.ts` (+ a season-level SSE hook)
+
+## Acceptance criteria
+
+- Standings table on season dashboard + session page updates live when a match is recorded
+- No page reload needed
+- Match removal also refreshes standings
+- No N+1: event is either lightweight or carries a single precomputed standings snapshot
+
+## Open questions / notes
+
+- Payload design: send computed standings vs just an invalidation signal (recommend signal + refetch for simplicity)

--- a/docs/features/09-elo-individual-vs-team.md
+++ b/docs/features/09-elo-individual-vs-team.md
@@ -1,0 +1,35 @@
+# elo-individual-vs-team Score Type
+
+## Summary
+
+Wire up the `elo-individual-vs-team` score type end-to-end. The ELO engine and DB schema already support it (`WEIGHTED_TEAMS` strategy); season creation only offers `elo` or `3-1-0`.
+
+## Why / Goal
+
+This is the mode for games where an individual player can face a team (e.g. king of the hill, singles vs pairs, fighting games with tag formats). The heavy lifting is done — exposing it is low effort and unlocks a new game format.
+
+## Scope
+
+- Accept `elo-individual-vs-team` in `season.create` validation
+- Team-size validation for this mode (one side size 1, other side 1..n, or defined rule)
+- Verify ELO weighting math via `WEIGHTED_TEAMS` strategy and add tests
+- UI: allow selecting the mode in the create-season dialog with an explanatory description
+- Standings/profiles already derive from `seasonPlayer`/`seasonTeam` so should work once matches can be created
+
+## Code map
+
+- Engine strategy: `packages/util/src/elo-util` (`WEIGHTED_TEAMS`), used in `apps/worker/src/repositories/match-repository.ts`
+- Schema enum: `apps/worker/src/db/schema/league-schema.ts` (`scoreType`)
+- Validation gate: `apps/worker/src/trpc/router/season-router.ts` `create` (currently `"elo" | "3-1-0"`)
+- Create-season UI: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/-components/seasons/create-season-form.tsx`
+
+## Acceptance criteria
+
+- A season of type `elo-individual-vs-team` can be created and matches recorded
+- ELO math produces expected outcomes in tests
+- Create-season dialog exposes the mode
+
+## Open questions / notes
+
+- Define the exact pairing rule (fixed 1vN? any?) before implementing
+- Confirm `getById`/profile pages that are ELO-only gate correctly for this type

--- a/docs/features/10-public-shareable-leaderboard.md
+++ b/docs/features/10-public-shareable-leaderboard.md
@@ -1,0 +1,35 @@
+# Public Shareable Leaderboard & Results Pages
+
+## Summary
+
+Read-only, publicly shareable league/season pages (standings, latest results) that non-members can view without signing up.
+
+## Why / Goal
+
+Office and friend leagues are social — people share results in chat and want to brag. Today everything requires an account + membership. A public URL per league/season is the cheapest virality + bragging-rights feature.
+
+## Scope
+
+- Opt-in "Make this league public" toggle in league settings (default off)
+- Public route rendering standings + recent results without auth
+- Share link (copy-to-clipboard) from the league page
+- No mutation capabilities on public pages; strip all editing UI
+- Optional: read-only "public only" exposure of a subset of analytics
+
+## Code map
+
+- Routes are under `_authenticated` today; a new public route tree is needed (e.g. `_public/leagues/$slug`), see `apps/web/src/routes/_public/home.tsx` for the public layout pattern
+- Data sources already exist and are auth-scoped: `seasonPlayer.getStanding`, `match.getAll`
+- League metadata/logo: `apps/worker/src/db/schema/league-schema.ts`
+
+## Acceptance criteria
+
+- Public toggle per league; when off, public URLs 404/redirect
+- Public page shows standings + latest results for the active season
+- Public page has no auth requirement and no write actions
+- Share-link button on league page
+
+## Open questions / notes
+
+- Privacy: default-off; consider what data leaks via player names/ELO
+- Cache-friendliness for public pages (edge caching opportunity)

--- a/docs/features/11-head-to-head-rivalries.md
+++ b/docs/features/11-head-to-head-rivalries.md
@@ -1,0 +1,34 @@
+# Head-to-Head Rivalry Records on Player Profiles
+
+## Summary
+
+Show per-pair head-to-head records ("Emma vs Fatima: 5W–2L") on player profiles and a dedicated rivalry view.
+
+## Why / Goal
+
+Rivalries are the emotional core of a competition app. The data already exists (`comparePlayers`, per-opponent breakdown) but is only surfaced via the explicit compare page. Making it visible per-player turns passive stats into stories.
+
+## Scope
+
+- On player profile, list opponents ordered by matches played with W/D/L record
+- Link each opponent row to the compare page
+- Optional: "rival" highlight (most-played / most contentious opponent)
+- Team equivalent (team vs team records already exist via `getRivalTeams`)
+
+## Code map
+
+- Per-opponent W/L breakdown: `apps/worker/src/trpc/router/player-router.ts` (`getPlayerStats`)
+- Compare: `apps/worker/src/trpc/router/player-router.ts` (`comparePlayers`), UI at `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/players/compare.tsx`
+- Team rivalries: `apps/worker/src/trpc/router/league-team-router.ts` (`getRivalTeams`)
+- Player profile UI: `.../players/$leaguePlayerId/index.tsx`
+
+## Acceptance criteria
+
+- Player profile shows head-to-head list with W/D/L + link to compare
+- Query is a single join (no N+1 per opponent)
+- Works for ELO seasons (profile pages are ELO-gated today)
+
+## Open questions / notes
+
+- Where to place on profile (existing "Best/Worst Teammate" cards area or new tab)
+- Pagination for opponents with many matches

--- a/docs/features/12-guest-player-claiming.md
+++ b/docs/features/12-guest-player-claiming.md
@@ -1,0 +1,35 @@
+# Guest Player Claiming Journey
+
+## Summary
+
+Make the existing guest→registered-user claim flow a first-class, discoverable experience instead of relying purely on invitation emails.
+
+## Why / Goal
+
+Guest players are created by admins with an email + display name. When a real user signs up with that email, an invite is auto-sent — but the flow is invisible and easy to miss. Converting guests to full accounts is a key activation win.
+
+## Scope
+
+- Surface pending claims: "You have a guest profile waiting" banner on signup/sign-in for matching emails
+- Walk the user through claiming: set name/password → claim existing player records + match history
+- Reuse the existing auto-invitation hook; add the claim UI and linking
+- Handle the case where a guest email is already claimed
+
+## Code map
+
+- Auto-invitation/claim hook: `apps/worker/src/lib/better-auth-organization-hooks.ts` (guest→user claim)
+- Invitation accept route: `apps/web/src/routes/accept-invitation.$invitationId.tsx`
+- Guest creation/edit: `apps/worker/src/trpc/router/player-router.ts` (`createGuestPlayer`, `editGuestPlayer`)
+- Sign-up UI: `apps/web/src/routes/_auth/auth/-components/sign-up-form.tsx`
+
+## Acceptance criteria
+
+- A user signing up with a guest-owned email sees a clear "claim your profile" path
+- Claiming links existing player records/history to the account
+- Claimed email can no longer be claimed again
+- Works with the existing `editGuestPlayer` repointing logic
+
+## Open questions / notes
+
+- Can a claim merge two accounts (registered user already has a player)? Keep simple: claim only if no player for that email yet.
+- Copy/tone of the claim banner

--- a/docs/features/13-csv-export.md
+++ b/docs/features/13-csv-export.md
@@ -1,0 +1,33 @@
+# Standings & Stats CSV Export
+
+## Summary
+
+Export standings, match lists, and player stats to CSV for league organizers.
+
+## Why / Goal
+
+Office leagues commonly need results for prizes, spreadsheets, or internal leaderboards. A one-click export is cheap and high-value for organizers.
+
+## Scope
+
+- Export buttons on: season standings, matches list, players list, team standings
+- Server-side CSV generation (tRPC query returning CSV text) or client-side from fetched data
+- Filename with league/season/date; proper UTF-8 + escaping
+- Export respects current filters where feasible
+
+## Code map
+
+- Data already available via `seasonPlayer.getStanding`, `match.getAll`, `leagueTeam.list`, `player.getAll`
+- Export actions: `apps/worker/src/trpc/router/` (or a small new `export` router)
+- UI buttons: season dashboard `.../seasons/$seasonSlug/index.tsx`, matches page `.../matches.tsx`
+
+## Acceptance criteria
+
+- CSV downloads from the three primary lists (standings, matches, players)
+- Exported file opens correctly in Excel/Numbers (BOM, comma handling)
+- Matches existing pagination (export full dataset, not just current page)
+
+## Open questions / notes
+
+- Client vs server generation: server-side preferred for consistency with filters/permissions
+- Include team standings too (low extra cost)

--- a/docs/features/14-admin-ban-impersonation.md
+++ b/docs/features/14-admin-ban-impersonation.md
@@ -1,0 +1,36 @@
+# Admin: User Ban & Impersonation
+
+## Summary
+
+Implement platform-admin user banning and session impersonation. The schema (banned/banReason/banExpires, impersonatedBy) and auth plugin support already exist; admin stats hardcode `bannedUsers: 0`.
+
+## Why / Goal
+
+As the app grows, admins need moderation tools (ban abusive users, inspect accounts). Banning is schema-ready and cheap to finish; impersonation gives support a way to debug user-reported issues.
+
+## Scope
+
+- Ban/unban user with optional reason + expiry from the admin users page
+- Ban enforcement at auth/session level (blocked sign-in, revoked sessions)
+- Surface real `bannedUsers` count in admin stats
+- Impersonate a user (session with `impersonatedBy`) with a clear "viewing as" banner
+- Audit trail of ban/impersonation actions
+
+## Code map
+
+- Schema: `apps/worker/src/db/schema/auth-schema.ts` (banned fields, `impersonatedBy`)
+- Hardcoded value: `apps/worker/src/trpc/router/admin-router.ts` (`bannedUsers: 0`)
+- better-auth admin plugin already configured in `apps/worker/src/lib/better-auth.ts`
+- Admin UI: `apps/web/src/routes/_authenticated/admin/users/-components/admin-users-page.tsx`
+
+## Acceptance criteria
+
+- Admin can ban/unban a user with reason + expiry; banned user cannot sign in
+- Admin stats show a real banned-user count
+- Impersonation works with an obvious banner and safe exit
+- Actions are logged
+
+## Open questions / notes
+
+- Does better-auth ban enforcement require a hook, or is it built into the admin plugin? Verify with better-auth docs before implementing.
+- Impersonation permissions: admin role only

--- a/docs/features/15-pwa-push-notifications.md
+++ b/docs/features/15-pwa-push-notifications.md
@@ -1,0 +1,37 @@
+# PWA Install & Push Notifications
+
+## Summary
+
+Make Scorebrawl installable (PWA) and add push notifications so users get alerted when a session/match needs attention even when the tab is closed.
+
+## Why / Goal
+
+Sessions are live and real-time; the killer engagement loop is "your turn / match is live". PWA installability plus push turns a browser tab into something users can keep on their home screen, and push drives re-engagement.
+
+## Scope
+
+- Web app manifest + service worker (offline shell for installability)
+- Icon set + theme/color config
+- Push subscription storage + send path (uses Web Push API; Cloudflare Workers support)
+- Notify on: match recorded, streak milestone, achievement, session started, "you're up" in winner-stays
+- Notification click → navigate to the relevant route
+- Relies on 01-in-app-notifications for the event/notification source
+
+## Code map
+
+- Vite config + index.html: `apps/web` (manifest/service worker registration)
+- Notifications source: see `01-in-app-notifications.md`
+- Cloudflare Worker push: `apps/worker/src/index.ts` / a new `routes/push-router.ts`
+- Auth already has device/API key infra in `apps/worker/src/db/schema/device-code-schema.ts`
+
+## Acceptance criteria
+
+- App installable via browser (Lighthouse PWA criteria)
+- User can opt in to push; subscriptions stored server-side
+- Push delivered for configured event types; click routes correctly
+- Works in dev and production (VAPID keys configured)
+
+## Open questions / notes
+
+- Depends on 01-in-app-notifications (event plumbing) — sequence after it
+- iOS Safari push caveats; scope messaging accordingly

--- a/docs/features/16-mobile-polish.md
+++ b/docs/features/16-mobile-polish.md
@@ -1,0 +1,33 @@
+# Mobile-First Polish Pass
+
+## Summary
+
+Audit and improve the mobile experience. The session dialog already has mobile step-based navigation; other primary flows are desktop-first.
+
+## Why / Goal
+
+Live sessions happen around a physical table/office with phones. If match recording and session management work well on mobile, the app is usable in the moment it matters most.
+
+## Scope
+
+- Mobile audit of primary flows: session, match entry, standings, player profiles
+- Fix touch targets, horizontal scroll, responsive tables (standings), sheet/drawer usage on small screens
+- Confirm match creation + session "start match" flows are fully usable on mobile
+- Test on a phone-size viewport (agent-browser device emulation)
+
+## Code map
+
+- Mobile handling reference: `apps/web/src/routes/_authenticated/_sidebar/leagues/$slug/seasons/$seasonSlug/session/$sessionId/-components/winner-stays/winner-stays-session.tsx` and the start-session dialog (step layout)
+- Standings table: `-components/season/standing.tsx` / `session-standings.tsx`
+- UI primitives: `apps/web/src/routes/-components/ui/*` (Drawer, Sheet already exist)
+
+## Acceptance criteria
+
+- Match entry and session controls are usable on a phone viewport
+- No horizontal page scroll on core pages
+- Standings readable on mobile (scroll/collapse pattern)
+- Verified via device-emulated browser
+
+## Open questions / notes
+
+- Run as a bug-hunt + fixes pass rather than a redesign; gather a concrete list first

--- a/docs/features/17-api-key-management.md
+++ b/docs/features/17-api-key-management.md
@@ -1,0 +1,35 @@
+# API Key Management UI
+
+## Summary
+
+Provide a UI to create and manage API keys. The better-auth admin plugin and `apikey` table exist; there is no user-facing key management surface.
+
+## Why / Goal
+
+Programmatic access (scripts, integrations, the MCP client) needs scoped credentials. Today keys can't be created/managed without admin plumbing. A self-service key UI enables integrations and power users.
+
+## Scope
+
+- Profile/league settings page: create API key with permissions + expiry
+- List, revoke, and delete keys
+- Show the key once at creation (copy to clipboard)
+- Scope keys to a league/org where applicable
+- Rate-limit display (better-auth tracks usage)
+
+## Code map
+
+- Table: `apps/worker/src/db/schema/auth-schema.ts` (`apikey` with rate limiting + permissions)
+- Plugin wiring: `apps/worker/src/lib/better-auth.ts` (admin plugin)
+- Profile page: `apps/web/src/routes/_authenticated/_sidebar/profile.tsx`
+- MCP client auth reference: `packages/mcp`
+
+## Acceptance criteria
+
+- User can create, copy, list, revoke, and delete API keys
+- Keys carry permission scopes that are enforced server-side
+- Key creation is surfaced in a settings section (not admin-only)
+
+## Open questions / notes
+
+- Key storage/serialization handled by better-auth admin plugin; confirm exact API before wiring UI
+- Whether keys should be admin-created only for now (scoped to admins) vs all users

--- a/docs/features/18-ai-weekly-recaps.md
+++ b/docs/features/18-ai-weekly-recaps.md
@@ -1,0 +1,36 @@
+# AI Weekly Recaps & Match Narratives
+
+## Summary
+
+Auto-generate narrative summaries — weekly league recaps and match highlights — using the rich analytics already available (upsets, streaks, records, win probability).
+
+## Why / Goal
+
+The data layer (tRPC + 34 MCP tools) is deep but static. AI-generated recaps turn raw numbers into shareable, delightful content that drives engagement and gives the league something to talk about.
+
+## Scope
+
+- Weekly recap: movers, upsets, streaks, record-breakers, standout performances (player/team)
+- Match narrative: one-paragraph story per notable match (upset, comeback, blowout)
+- Generation via an AI provider call (worker fetch to LLM) with structured inputs from existing stats
+- Preview + publish flow; recap stored and shown on the season page / activity feed
+- Reuse existing stats logic (upsets, biggest margins, most improved, streaks)
+
+## Code map
+
+- Analytics logic already in: `apps/worker/src/services/mcp-tools/tool-executors.ts` (get_upsets, get_biggest_margins, get_most_improved, get_streaks, get_win_probability, get_season_highlights)
+- Weekly stats: `seasonPlayer.getWeeklyStats`, `seasonTeam.getWeeklyStats`
+- LLM call: add a service in `apps/worker/src/services/` (Cloudflare Worker `fetch` to provider)
+- Display: season dashboard `.../seasons/$seasonSlug/index.tsx` / `04-league-activity-feed.md`
+
+## Acceptance criteria
+
+- A weekly recap can be generated from a season's data and rendered on the season page
+- Notable-match narrative generation works for flagged matches
+- Generation is async/queued (not blocking match entry), with preview before publish
+- Token/cost guardrails (rate-limit generation, cache per week)
+
+## Open questions / notes
+
+- Which AI provider/key to use in the worker (no provider wired yet in worker)
+- Keep human-in-the-loop (preview) vs fully automatic

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,28 @@
+# Feature Backlog
+
+Candidate features from a full app walkthrough + codebase triage (browser session + backend surface map). Each file is intentionally short — enough context to start work, not a spec.
+
+**Priority ordering** (01 = highest) reflects estimated ROI: closes an obvious product gap, leverages infrastructure that already exists, and/or drives engagement. Order is a discussion starting point, not final.
+
+| #   | Feature                                                            | Rationale for priority                                                             |
+| --- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| 01  | [In-app notifications](01-in-app-notifications.md)                 | Foundations for streaks/achievements/sessions; all event infra exists              |
+| 02  | [Achievements showcase](02-achievements-showcase.md)               | Engine fully built, invisible in UI; pure win                                      |
+| 03  | [Season close ceremony](03-season-close-ceremony.md)               | Completes the core season loop; awards declared-but-never-computed `season_winner` |
+| 04  | [League activity feed](04-league-activity-feed.md)                 | Surfaces all existing analytics as a living timeline                               |
+| 05  | [Team management CRUD](05-team-management-crud.md)                 | Obvious gap; repo functions already exist                                          |
+| 06  | [Manual session lineup](06-manual-session-lineup.md)               | `manual` rotation mode is a stub                                                   |
+| 07  | [Fixtures / 3-1-0 UX](07-fixtures-points-season-ux.md)             | Points seasons generate fixtures with minimal UI                                   |
+| 08  | [Real-time standings SSE](08-standings-realtime-sse.md)            | Declared event never emitted; tiny change, big polish                              |
+| 09  | [elo-individual-vs-team](09-elo-individual-vs-team.md)             | Engine + schema ready; just not exposed                                            |
+| 10  | [Public shareable leaderboard](10-public-shareable-leaderboard.md) | Social sharing / virality for office leagues                                       |
+| 11  | [Head-to-head rivalries](11-head-to-head-rivalries.md)             | Rivalries are the emotional core; data exists                                      |
+| 12  | [Guest player claiming](12-guest-player-claiming.md)               | Converts guests to active accounts                                                 |
+| 13  | [CSV export](13-csv-export.md)                                     | Cheap organizer utility                                                            |
+| 14  | [Admin ban & impersonation](14-admin-ban-impersonation.md)         | Moderation; schema-ready                                                           |
+| 15  | [PWA + push notifications](15-pwa-push-notifications.md)           | Depends on 01; retention loop                                                      |
+| 16  | [Mobile polish](16-mobile-polish.md)                               | Bug-hunt + fixes pass                                                              |
+| 17  | [API key management UI](17-api-key-management.md)                  | Enables integrations                                                               |
+| 18  | [AI weekly recaps](18-ai-weekly-recaps.md)                         | Bigger bet; needs AI provider wiring                                               |
+
+Suggested sequencing note: 01 → 02 → 03 form a coherent "engagement" slice and build on the same event/achievement plumbing. 05 and 06 are independent and cheap. 15 depends on 01.


### PR DESCRIPTION
## Summary
Feature backlog from a full app walkthrough + backend triage. 18 candidate features documented as brief, work-startable briefs in `docs/features/`, priority-ordered via filename prefix (01 = highest).

## What's here
- 18 feature briefs (Summary / Why / Scope / Code map / Acceptance criteria / Open questions)
- `README.md` indexes the backlog with the priority rationale
- Priorities favor closing obvious product gaps and leveraging infra that already exists (SSE, achievement engine, repo functions)

## Top of the backlog
1. **In-app notifications** — event infra already exists
2. **Achievements showcase** — engine built, invisible in UI
3. **Season close ceremony** — awards the declared-but-never-computed `season_winner` achievement
4. **League activity feed**
5. **Team management CRUD** — repo functions already exist

## Purpose
Discussion artifact — no code changes. Let's use the PR to align on priorities, merge/trim/split stories, and pick what to take forward.

## Suggested sequencing
01 → 02 → 03 form a coherent engagement slice (same event/achievement plumbing). 05, 06 are independent and cheap. 15 (PWA/push) depends on 01.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788951309&installation_model_id=19942&pr_number=647&repository=thor-coding-cowboys%2Fscorebrawl&return_to=https%3A%2F%2Fgithub.com%2Fthor-coding-cowboys%2Fscorebrawl%2Fpull%2F647&signature=c662c1318e54362d12b1f32446310561fae0ef9044cdc63d640537645c372d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->