### PR TITLE
fix: reflect accepted invite in session after accepting

### DIFF
--- a/apps/e2e/tests/invitation-flow.spec.ts
+++ b/apps/e2e/tests/invitation-flow.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect, generateTestUser, signUp, SEED_USER, SEED_LEAGUE } from "./fixtures/auth";
+
+test.describe("Invitation flow", () => {
+	test("accepted invitation is reflected in the session and navigates into the league", async ({
+		page,
+		request,
+	}) => {
+		const user = generateTestUser();
+
+		await page.goto("/auth/sign-in");
+		const origin = new URL(page.url()).origin;
+
+		// Create an invitation for the new user as the seeded league owner (API)
+		const signInRes = await request.post("/api/auth/sign-in/email", {
+			headers: { "Content-Type": "application/json" },
+			data: { email: SEED_USER.email, password: SEED_USER.password },
+		});
+		expect(signInRes.ok()).toBeTruthy();
+
+		const orgsRes = await request.get("/api/auth/organization/list");
+		const orgs = await orgsRes.json();
+		const seedOrg = orgs.find((o: { slug: string }) => o.slug === SEED_LEAGUE.slug);
+		expect(seedOrg).toBeDefined();
+
+		const inviteRes = await request.post("/api/auth/organization/invite-member", {
+			headers: { "Content-Type": "application/json", Origin: origin },
+			data: { organizationId: seedOrg.id, email: user.email, role: "member" },
+		});
+		expect(inviteRes.ok()).toBeTruthy();
+		const invite = await inviteRes.json();
+		expect(invite.id).toBeDefined();
+
+		// Clear the seed session before signing up the invited user
+		await request.post("/api/auth/sign-out", {
+			headers: { "Content-Type": "application/json", Origin: origin },
+			data: {},
+		});
+
+		// Sign up the invited user; the app should route them to the accept page
+		await signUp(page, user.name, user.email, user.password);
+		await expect(page).toHaveURL(new RegExp(`/accept-invitation/${invite.id}`), {
+			timeout: 15000,
+		});
+
+		// Accept the invitation
+		await page.getByRole("button", { name: "Accept Invitation" }).click();
+
+		// The session must reflect the accepted invite: navigate into the accepted league
+		await expect(page).toHaveURL(new RegExp(`/leagues/${SEED_LEAGUE.slug}`), {
+			timeout: 15000,
+		});
+
+		// Sidebar active league switches to the accepted league
+		await expect(
+			page.getByRole("button", { name: new RegExp(`/${SEED_LEAGUE.slug}`) })
+		).toBeVisible({ timeout: 15000 });
+
+		// No stale pending invitation: going home routes to the active league, not the accept page
+		await page.goto("/", { waitUntil: "networkidle" });
+		await expect(page).toHaveURL(new RegExp(`/leagues/${SEED_LEAGUE.slug}`), {
+			timeout: 15000,
+		});
+	});
+});

--- a/apps/web/src/routes/accept-invitation.$invitationId.tsx
+++ b/apps/web/src/routes/accept-invitation.$invitationId.tsx
@@ -14,7 +14,8 @@ import {
 	Alert02Icon,
 } from "@hugeicons/core-free-icons";
 import { useTRPC } from "@/lib/trpc";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { SESSION_QUERY_KEY } from "@/hooks/useSession";
 
 export const Route = createFileRoute("/accept-invitation/$invitationId")({
 	component: AcceptInvitationPage,
@@ -23,10 +24,17 @@ export const Route = createFileRoute("/accept-invitation/$invitationId")({
 function AcceptInvitationPage() {
 	const { invitationId } = Route.useParams();
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const [isAccepting, setIsAccepting] = useState(false);
 	const trpc = useTRPC();
 
-	const { data: session, isPending: isSessionLoading } = authClient.useSession();
+	const {
+		data: session,
+		isPending: isSessionLoading,
+		refetch: refetchSession,
+	} = authClient.useSession();
+	const { refetch: refetchOrganizations } = authClient.useListOrganizations();
+	const { refetch: refetchActiveMember } = authClient.useActiveMember();
 	const isAuthenticated = !!session?.user;
 
 	const {
@@ -91,7 +99,18 @@ function AcceptInvitationPage() {
 				}
 			} else if (data) {
 				toast.success("You have joined the league!");
-				void navigate({ to: "/leagues" });
+				// acceptInvitation doesn't refresh the client session/org caches, so
+				// invalidate them to reflect the accepted invite in the session
+				await queryClient.invalidateQueries({ queryKey: SESSION_QUERY_KEY });
+				await queryClient.invalidateQueries({
+					queryKey: trpc.member.listPendingInvitations.queryKey(),
+				});
+				await queryClient.invalidateQueries({ queryKey: trpc.league.list.queryKey() });
+				await Promise.all([refetchSession(), refetchOrganizations(), refetchActiveMember()]);
+				const leagueSlug = invitation?.league?.slug;
+				void navigate(
+					leagueSlug ? { to: "/leagues/$slug", params: { slug: leagueSlug } } : { to: "/leagues" }
+				);
 			}
 		} catch {
 			toast.error("An error occurred while accepting the invitation");
@@ -117,6 +136,9 @@ function AcceptInvitationPage() {
 				toast.error(error.message || "Failed to decline invitation");
 			} else {
 				toast.success("Invitation declined");
+				await queryClient.invalidateQueries({
+					queryKey: trpc.member.listPendingInvitations.queryKey(),
+				});
 			}
 			void navigate({ to: "/" });
 		} catch {


### PR DESCRIPTION
## Summary
Fixes the invite flow where, after accepting an invitation, the app kept showing the leagues list but the session never reflected the newly accepted league — the accepted invite wasn't entered/activated.

## Root cause
`acceptInvitation` (better-auth) updates the **server** session's `activeOrganizationId` correctly, but the **client** caches are never invalidated:
- better-auth client atoms (`session`, `listOrganizations`) only refresh on `set-active`/create/delete, not on `/organization/accept-invitation`
- the app's React Query session cache (`["auth","session"]`, 5-min staleTime) stays stale
- the trpc `listPendingInvitations` cache stays stale, so home kept re-redirecting to the already-accepted invite

So `/leagues` (a fresh trpc query) showed the new league, but the session/active-org-driven UI didn't pick it up.

## Changes
- `apps/web/src/routes/accept-invitation.$invitationId.tsx`:
  - On **accept**: invalidate session + pending-invitations + league-list caches, refetch the better-auth session/organizations/active-member atoms, and navigate straight into the accepted league (`/leagues/$slug`) so the active org is set and the session reflects it.
  - On **decline**: invalidate the pending-invitations cache so home doesn't loop back to a declined invite.
- `apps/e2e/tests/invitation-flow.spec.ts`: Playwright regression test covering accept → land in accepted league → session reflects it → no pending-invite loop.

## Verification
- New e2e test **fails without the fix** (stays on `/leagues` list) and **passes with it**
- `bun check` passes
- `bun run test` (174 worker tests) passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125078&installation_model_id=19942&pr_number=650&repository=thor-coding-cowboys%2Fscorebrawl&return_to=https%3A%2F%2Fgithub.com%2Fthor-coding-cowboys%2Fscorebrawl%2Fpull%2F650&signature=347ae5d854143806352f33c178cc2ed81b8bf73f38088c895c5024db0cce6de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->