### PR TITLE
chore: remove one-time d1_migrations remap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,6 @@ jobs:
       - name: 🔍 Wrangler Typecheck
         run: bun run wrangler-typecheck
 
-      - name: 🔁 Remap d1 migration names to nested layout
-        if: github.ref == 'refs/heads/main'
-        run: bunx wrangler d1 execute scorebrawl --remote --command "CREATE TABLE IF NOT EXISTS d1_migrations(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL); UPDATE d1_migrations SET name = replace(substr(name, instr(name,'_')+1), '.sql', '/migration.sql') WHERE name NOT LIKE '%/%';"
-        working-directory: apps/worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
       - name: 🗄️ Apply database migrations
         if: github.ref == 'refs/heads/main'
         run: bun run db:migrate:prod

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -17,7 +17,6 @@
 		"lint": "oxlint .",
 		"cf-typegen": "wrangler types",
 		"db:generate": "drizzle-kit generate",
-		"predb:migrate": "wrangler d1 execute scorebrawl --local --persist-to ../../.db/local --command \"CREATE TABLE IF NOT EXISTS d1_migrations(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL); UPDATE d1_migrations SET name = replace(substr(name, instr(name,'_')+1), '.sql', '/migration.sql') WHERE name NOT LIKE '%/%';\"",
 		"db:migrate": "wrangler d1 migrations apply scorebrawl --local --persist-to ../../.db/local",
 		"db:clean": "rm -rf ../../.db/local",
 		"db:reset": "bun run db:clean && bun run db:migrate",


### PR DESCRIPTION
## Summary
Follow-up to #652. Removes the flat→nested `d1_migrations` remap now that it has done its job everywhere it needed to:

- **Production**: applied manually and verified before merging #652, then confirmed as a no-op in the CI run that followed the merge.
- **CI**: the remap step no-op'd on that same run (0 rows matched).

## What's removed
- The CI step `🔁 Remap d1 migration names to nested layout` (`.github/workflows/ci.yml`)
- The local `predb:migrate` hook (`apps/worker/package.json`)

## What's kept
- The nested migration folders themselves (including `squash_baseline` and the `issuer` migration) — these are permanent migration history, needed for fresh DBs (new preview environments, new dev machines) and for `drizzle-kit generate` to keep working.
- The historical spec/plan docs describing the original migration — left as a record.

## ⚠️ For teammates
If you have a **local dev DB from before #652** that you haven't run `db:migrate` against since, it never got the one-time remap. Without this hook, your next `db:migrate` will see all migrations as "unapplied" and try to re-run them (will fail — tables already exist). Fix: `bun db:reset` (wipes local DB, re-applies cleanly from the nested migrations — no data loss beyond your local dev data).

Fresh local DBs (new clones, or anyone who already ran `db:reset`/`db:migrate` after #652) never needed the remap and are unaffected.

## Verification
- `bun typecheck`, `bun lint`, `bun format` pass
- `bun run db:migrate` locally still reports "No migrations to apply!" without the removed hook (confirms my own local DB, already remapped, is unaffected)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789678994&installation_model_id=19942&pr_number=653&repository=thor-coding-cowboys%2Fscorebrawl&return_to=https%3A%2F%2Fgithub.com%2Fthor-coding-cowboys%2Fscorebrawl%2Fpull%2F653&signature=6b72fb77ee8cd98c689e4884c27f7303a072e8a53c9a5aec829243a759babe27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->