### PR TITLE
fix(e2e): skip real email sending during e2e runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,7 @@ apps/web/.tanstack/
 .wrangler/
 .env*
 !.env.example
+!apps/worker/.env.e2e
 .dev.vars*
 !.dev.vars.example
 

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -48,6 +48,10 @@ export default defineConfig({
 		stdout: "pipe",
 		stderr: "pipe",
 		ignoreHTTPSErrors: true,
+		// Loads apps/worker/.env.e2e (overrides apps/worker/.env) so real emails
+		// are never sent during e2e runs - the worker falls back to console.log
+		// when RESEND_API_KEY is empty. See apps/worker/.env.e2e.
+		env: { CLOUDFLARE_ENV: "e2e" },
 		// Wait for Vite to report ready (Vite 6 uses "VITE v" message).
 		// Regex must tolerate ANSI color codes present in piped output.
 		wait: {

--- a/apps/worker/.env.e2e
+++ b/apps/worker/.env.e2e
@@ -1,0 +1,6 @@
+# Loaded on top of .env when CLOUDFLARE_ENV=e2e (see apps/e2e/playwright.config.ts).
+# Overrides only the vars that must differ during e2e runs.
+
+# Force the console.log fallback in better-auth.ts instead of sending real
+# emails via Resend, so e2e runs never trigger bounces/real invitation emails.
+RESEND_API_KEY=


### PR DESCRIPTION
## Problem
Playwright's `webServer` reuses `apps/worker/.env` (same file local dev uses), which has a real `RESEND_API_KEY`. This caused e2e test runs to actually send invitation emails to fake test addresses (e.g. `test-*@e2e.test`), which then bounce in Resend.

## Fix
- Add `apps/worker/.env.e2e` overriding `RESEND_API_KEY` to empty.
- Set `CLOUDFLARE_ENV=e2e` on Playwright's `webServer.env` so the Cloudflare Vite plugin loads `.env.e2e` on top of `.env` for e2e runs (verified this merge behavior directly against `unstable_getVarsForDev`).
- No code change needed — `better-auth.ts` already falls back to `console.log`-ing the invitation link when `RESEND_API_KEY` is empty.
- `.gitignore` updated to allow committing `apps/worker/.env.e2e` (no secrets, needed for CI/other devs).

## Notes
- Doesn't affect regular local dev (`bun dev`) — real key still used there.
- If Playwright reuses an already-running dev server (default outside CI), that server needs to have been started with `CLOUDFLARE_ENV=e2e` to pick this up; in CI a fresh server is always spawned so this is moot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789810425&installation_model_id=19942&pr_number=654&repository=thor-coding-cowboys%2Fscorebrawl&return_to=https%3A%2F%2Fgithub.com%2Fthor-coding-cowboys%2Fscorebrawl%2Fpull%2F654&signature=ff476178572d0225f828a87cd5031b8645d446320b61a89447221261219187bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->