### PR TITLE
chore: add timeout-minutes to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   ci:
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
     env:
       VITE_GITHUB_CLIENT_ID: Ov23liEHPLUdBgTj5Cxu # https://github.com/organizations/thor-coding-cowboys/settings/applications/3369260
       VITE_GOOGLE_CLIENT_ID: 972190779505-ob8vi6970ib3c8i46plgmu4i9cpr7ohg.apps.googleusercontent.com

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -15,6 +15,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     continue-on-error: true
 
     permissions:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,7 @@ jobs:
   deploy-preview:
     if: github.event.action != 'closed'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -173,6 +174,7 @@ jobs:
   cleanup-preview:
     if: github.event.action == 'closed'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Adds a `timeout-minutes` guard to every job in the GitHub Actions workflows to prevent runaway jobs from consuming excess build minutes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thor-coding-cowboys/codesmith/scorebrawl/pr/655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790076855&installation_model_id=19942&pr_number=655&repository=thor-coding-cowboys%2Fscorebrawl&return_to=https%3A%2F%2Fgithub.com%2Fthor-coding-cowboys%2Fscorebrawl%2Fpull%2F655&signature=423dfe47c6c1f944cbe83812b7d6707d111c5447131588491efacf1deac03b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->